### PR TITLE
fix: add prepare script so dist/ is built on git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
Adds `prepare` to `scripts` in `package.json`.\n\nWhen consumers install this package directly from Git (e.g. `npm install github:Extra-Chill/chat`), npm runs the `prepare` script automatically after cloning. Without it, the `dist/` directory (which is gitignored) is never built, leaving the package broken for downstream consumers.\n\nCloses #18.