### PR TITLE
chore: normalize repository.url to git+https scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Extra-Chill/chat.git"
+    "url": "git+https://github.com/Extra-Chill/chat.git"
   },
   "homepage": "https://github.com/Extra-Chill/chat",
   "bugs": "https://github.com/Extra-Chill/chat/issues",


### PR DESCRIPTION
Silences the `npm publish` warning about auto-correcting the repository URL format. No functional change.