### PR TITLE
Forward onToolCalls and sessionContext from <Chat> to useChat

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useRef } from 'react';
-import type { ChatMessage as ChatMessageType, ContentFormat } from './types/index.ts';
+import type { ChatMessage as ChatMessageType, ContentFormat, ToolCall } from './types/index.ts';
 import type { FetchFn, MediaUploadFn } from './api.ts';
 import type { ToolGroup } from './components/ToolMessage.tsx';
 import { useChat, type UseChatOptions } from './hooks/useChat.ts';
@@ -59,6 +59,25 @@ export interface ChatProps {
 	onError?: UseChatOptions['onError'];
 	/** Called when a new message is added. */
 	onMessage?: UseChatOptions['onMessage'];
+	/**
+	 * Called with the tool calls emitted by every assistant turn.
+	 *
+	 * Fires once per continuation batch with a flat array of
+	 * {@link ToolCall} records. Use this to react to server-side side
+	 * effects (e.g. invalidate a TanStack Query cache when a tool
+	 * mutates server state).
+	 */
+	onToolCalls?: (toolCalls: ToolCall[]) => void;
+	/**
+	 * Session-list scope filter passed to the backend.
+	 *
+	 * The chat REST contract accepts a `context` query param on
+	 * `/sessions` so multiple chat surfaces (e.g. a sidebar in the
+	 * admin UI and a floating widget on the frontend) can share a
+	 * store without cross-contaminating their session lists. The value
+	 * is opaque to this package — the backend decides how to scope.
+	 */
+	sessionContext?: string;
 	/** Additional CSS class name on the root element. */
 	className?: string;
 	/** Whether to show the session switcher. Defaults to true. */
@@ -175,6 +194,8 @@ export function Chat({
 	maxContinueTurns,
 	onError,
 	onMessage,
+	onToolCalls,
+	sessionContext,
 	className,
 	showSessions = true,
 	sessionUi = 'list',
@@ -203,6 +224,8 @@ export function Chat({
 		maxContinueTurns,
 		onError,
 		onMessage,
+		onToolCalls,
+		sessionContext,
 		metadata,
 		mediaUploadFn,
 	});


### PR DESCRIPTION
## Summary

The composed `<Chat>` component already forwards 20+ `useChat` options to the underlying hook, but two were missing from that bridge:

- **`onToolCalls`** — fires once per assistant continuation batch with all tool calls that ran that turn. Consumers use this to react to server state mutations (e.g. TanStack Query cache invalidation when an AI tool creates a post or flips a setting).
- **`sessionContext`** — scopes the session list returned by the `/sessions` endpoint. Lets multiple chat surfaces (admin sidebar, frontend floating widget) share a backend store without cross-contaminating their session lists.

Both have been supported on the `useChat` hook since v0.10.0, so consumers that wanted them had to drop the composed `<Chat>` and hand-wire `useChat` + `ChatMessages` + `ChatInput` + `TypingIndicator` + `SessionSwitcher` themselves. That defeats the point of shipping a composed component.

## Fix

Add both props to `ChatProps` and forward them to the internal `useChat` call unchanged.

## Compat

- **Additive only.** Both props default to `undefined`.
- No behaviour change for existing consumers.

## Motivation

Data Machine's admin ChatSidebar currently uses `useChat` + hand-wired primitives specifically because of these two gaps. With this PR it can migrate to the composed `<Chat>` component, which deletes a fair amount of bespoke boilerplate on the DM side.

## Validation

- `npm run build` (tsc) passes cleanly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Audited the `<Chat>` vs `useChat` prop surface while prepping a DM consumer migration, drafted the additive forwarding. Chris flagged the broader audit target.