### PR TITLE
parseCanonicalDiff: recognize PendingAction `preview` nesting

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -91,7 +91,25 @@ export function parseCanonicalDiff( value: unknown ): CanonicalDiffData | null {
 	}
 
 	const container = isRecord( value.data ) ? value.data : value;
-	const rawDiff = isRecord( container.diff ) ? container.diff : container;
+
+	// Resolve the nested diff object. Preferred nesting keys, in order:
+	//   - `preview`  — emitted by Data Machine's PendingActionHelper::stage()
+	//                  envelope (unified pending-action primitive).
+	//   - `preview_data` — same idea, snake_case variant some backends emit
+	//                  when the envelope is serialized without camelCase
+	//                  normalization.
+	//   - `diff`     — historical shape from before the pending-action
+	//                  unification.
+	// If none match, the payload is assumed to already be flat (the rare
+	// case where a backend builds the CanonicalDiffData by hand without
+	// wrapping it in an envelope).
+	const rawDiff = isRecord( container.preview )
+		? container.preview
+		: isRecord( container.preview_data )
+			? container.preview_data
+			: isRecord( container.diff )
+				? container.diff
+				: container;
 
 	// Resolve the pending-action id. Prefer the canonical `actionId`
 	// (server unified on pending-action vocabulary in mid-2026) and


### PR DESCRIPTION
## Summary

Data Machine's unified `PendingActionHelper::stage()` returns an envelope that serializes the preview payload under a `preview` key:

```json
{
  "staged": true,
  "action_id": "abc123",
  "kind": "edit_post_blocks",
  "preview": { "actionId": "abc123", "diffType": "edit", "originalContent": "...", "replacementContent": "..." },
  "resolve_with": "resolve_pending_action"
}
```

Some backends emit the snake_case variant `preview_data` when the envelope is serialized without camelCase normalization.

The current `parseCanonicalDiff` only checks `container.diff` before falling through to the flat container. The real diff data nested under `preview` / `preview_data` is never extracted. Consumers that ran against this shape had to fork and maintain a parallel parser — `data-machine-editor` carries a duplicate `canonicalDiff.ts` that exists specifically to understand `container.preview`.

## Fix

Add `preview` and `preview_data` to the nesting-key resolution chain ahead of `diff`:

```ts
const rawDiff = isRecord( container.preview )
    ? container.preview
    : isRecord( container.preview_data )
        ? container.preview_data
        : isRecord( container.diff )
            ? container.diff
            : container;
```

## Compat

- **Strictly additive.** Payloads that use the old `diff` nesting or flat shape keep working.
- New priority: `preview` → `preview_data` → `diff` → flat.

## Unlocks

- `data-machine-editor` can delete its local `src/diff/canonicalDiff.ts` (92 lines) and its parallel `CanonicalDiffData` / `CanonicalDiffType` / `CanonicalDiffItem` type declarations, importing them from `@extrachill/chat` instead.
- Follow-up PR is queued on the editor side against the version that ships this change.

## Validation

- `npm run build` (tsc) passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced DM's pending-action envelope through `EditPostBlocksAbility` → `PendingActionHelper::stage()` → the tool result message content, compared against the editor's parallel parser at `data-machine-editor/src/diff/canonicalDiff.ts`, drafted the additive nesting key. Chris flagged the editor alignment.