### PR TITLE
chore: wire nodejs extension for automated releases

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,12 +1,15 @@
 {
   "auto_cleanup": false,
   "changelog_target": "CHANGELOG.md",
+  "extensions": {
+    "nodejs": {}
+  },
   "id": "chat",
   "remote_path": "",
   "version_targets": [
     {
       "file": "package.json",
-      "pattern": "\"version\": \"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `extensions.nodejs` to `homeboy.json` so `homeboy release chat` runs the full nodejs release pipeline: build → tag → push → **GitHub Release** → **npm publish** → cleanup.

Also tightens the `version_targets` pattern to allow whitespace variation (`"version":\s*"…"`) — matches the canonical shape from the nodejs extension manifest.

## Why

Releases up to v0.11.0 were done manually (`npm publish` by hand) and `chat` had **zero GitHub Releases** while sibling packages do. This brings `chat` in line with the recently-wired sibling packages:

- `extrachill-api-client`
- `extrachill-components`
- `extrachill-tokens`

## Verified

Dry-run plan against this branch:

```
homeboy release chat --bump patch --dry-run --skip-checks
```

Pipeline plan now includes both `github.release` and `publish.nodejs` steps. `homeboy build chat` cleanly runs `tsc` via the extension's build runner. No errors.

## Out of scope

The package is already published as `@extrachill/chat@0.11.0` on npm (public). Default `access: public` on the nodejs extension matches, so no overrides needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)