### PR TITLE
Collapse orphaned tool result messages

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -485,10 +485,15 @@
    ============================================ */
 
 .ec-chat-tool {
+	align-self: stretch;
+	box-sizing: border-box;
 	margin: 4px var(--ec-chat-padding);
+	max-width: calc(100% - (var(--ec-chat-padding) * 2));
+	min-width: 0;
 	border: 1px solid var(--ec-chat-tool-border);
 	border-radius: 8px;
 	background: var(--ec-chat-tool-bg);
+	color: var(--ec-chat-text);
 	overflow: hidden;
 	font-size: 13px;
 }
@@ -498,6 +503,7 @@
 	align-items: center;
 	gap: 8px;
 	width: 100%;
+	min-width: 0;
 	padding: 8px 12px;
 	border: none;
 	background: transparent;
@@ -523,6 +529,10 @@
 
 .ec-chat-tool__name {
 	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .ec-chat-tool__chevron {
@@ -549,7 +559,9 @@
 }
 
 .ec-chat-tool__json {
+	box-sizing: border-box;
 	margin: 0;
+	max-width: 100%;
 	padding: 8px;
 	background: var(--ec-chat-bg);
 	border: 1px solid var(--ec-chat-tool-border);

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -216,7 +216,16 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 
 		// Handle orphaned tool_result messages
 		if (msg.role === 'tool_result' && showTools && !processedToolResults.has(msg.id)) {
-			items.push({ type: 'message', message: msg });
+			items.push({
+				type: 'tool-group',
+				group: {
+					callMessage: msg,
+					resultMessage: msg,
+					toolName: msg.toolResult?.toolName ?? 'unknown',
+					parameters: {},
+					success: msg.toolResult?.success ?? null,
+				},
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Render orphaned `tool_result` messages through the collapsible `ToolMessage` UI instead of normal chat bubbles.
- Give tool blocks explicit text color and flex sizing so they remain visually distinct and fit inside narrow chat sidebars.
- Truncate long tool names in the collapsed header while keeping result JSON scrollable inside the tool card.

## Testing
- `npm install`
- `npm run build`
- `homeboy lint --path . --extension nodejs`
- `homeboy test --path . --extension nodejs` (runner reports `No package.json found at or above .`; package-level build was used as the effective check)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the tool-result rendering path, drafted the UI/CSS fix, and ran local verification. Chris remains responsible for review and acceptance.