### PR TITLE
Add generic switcher labels

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -579,6 +579,39 @@
    Session Switcher
    ============================================ */
 
+.ec-chat-agents {
+	border-bottom: 1px solid var(--ec-chat-border);
+	padding: 8px var(--ec-chat-padding);
+}
+
+.ec-chat-agents__select-wrap {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.ec-chat-agents__title {
+	flex-shrink: 0;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--ec-chat-text-muted);
+}
+
+.ec-chat-agents__select {
+	flex: 1;
+	min-width: 0;
+	padding: 6px 28px 6px 10px;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 6px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text);
+	font: inherit;
+}
+
+.ec-chat-agents__empty {
+	color: var(--ec-chat-text-muted);
+}
+
 .ec-chat-sessions {
 	border-bottom: 1px solid var(--ec-chat-border);
 }

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -84,6 +84,10 @@ export interface ChatProps {
 	showSessions?: boolean;
 	/** Session UI mode. 'list' renders the built-in switcher, 'none' lets the consumer render its own. */
 	sessionUi?: ChatSessionUi;
+	/** Visible title for the built-in session switcher. */
+	sessionSwitcherTitle?: string;
+	/** Accessible label for the built-in session select. */
+	sessionSwitcherSelectLabel?: string;
 	/** Label shown during multi-turn processing. */
 	processingLabel?: (turnCount: number) => string;
 	/**
@@ -199,6 +203,8 @@ export function Chat({
 	className,
 	showSessions = true,
 	sessionUi = 'list',
+	sessionSwitcherTitle,
+	sessionSwitcherSelectLabel,
 	processingLabel,
 	loadingMessages,
 	allowAttachments,
@@ -275,6 +281,8 @@ export function Chat({
 							onNew={chat.newSession}
 							onDelete={chat.deleteSession}
 							loading={chat.sessionsLoading}
+							title={sessionSwitcherTitle}
+							selectLabel={sessionSwitcherSelectLabel}
 						/>
 					)}
 

--- a/src/components/AgentSwitcher.tsx
+++ b/src/components/AgentSwitcher.tsx
@@ -1,0 +1,73 @@
+export interface AgentSwitcherAgent {
+	/** Stable agent identifier used as the select value. */
+	id: string;
+	/** Human-readable agent name. */
+	name: string;
+	/** Optional short description for consumers that display richer options. */
+	description?: string;
+}
+
+export interface AgentSwitcherProps {
+	/** Available agents. */
+	agents: AgentSwitcherAgent[];
+	/** Currently selected agent ID. */
+	activeAgentId?: string;
+	/** Called when a different agent is selected. */
+	onSelect: (agentId: string) => void;
+	/** Visible switcher title. Defaults to 'Agent'. */
+	title?: string;
+	/** Accessible label for the select. Defaults to 'Select agent'. */
+	selectLabel?: string;
+	/** Placeholder shown when there are no agents. Defaults to 'No agents available'. */
+	emptyLabel?: string;
+	/** Whether the switcher is disabled. */
+	disabled?: boolean;
+	/** Additional CSS class name. */
+	className?: string;
+}
+
+/**
+ * Generic agent switcher dropdown.
+ *
+ * Consumers provide the agent list and persistence behavior. The component only
+ * owns accessible, reusable switcher markup and styling hooks.
+ */
+export function AgentSwitcher({
+	agents,
+	activeAgentId,
+	onSelect,
+	title = 'Agent',
+	selectLabel = 'Select agent',
+	emptyLabel = 'No agents available',
+	disabled = false,
+	className,
+}: AgentSwitcherProps) {
+	const baseClass = 'ec-chat-agents';
+	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const currentAgentId = activeAgentId ?? agents[0]?.id ?? '';
+
+	return (
+		<div className={classes}>
+			<label className={`${baseClass}__select-wrap`}>
+				<span className={`${baseClass}__title`}>{title}</span>
+				{agents.length > 0 ? (
+					<select
+						className={`${baseClass}__select`}
+						value={currentAgentId}
+						onChange={(event) => onSelect(event.target.value)}
+						aria-label={selectLabel}
+						disabled={disabled}
+					>
+						{agents.map((agent) => (
+							<option key={agent.id} value={agent.id}>
+								{agent.name}
+							</option>
+						))}
+					</select>
+				) : (
+					<span className={`${baseClass}__empty`}>{emptyLabel}</span>
+				)}
+			</label>
+		</div>
+	);
+}

--- a/src/components/SessionSwitcher.tsx
+++ b/src/components/SessionSwitcher.tsx
@@ -13,6 +13,18 @@ export interface SessionSwitcherProps {
 	onDelete?: (sessionId: string) => void;
 	/** Whether sessions are currently loading. */
 	loading?: boolean;
+	/** Visible switcher title. Defaults to 'Conversations'. */
+	title?: string;
+	/** Accessible label for the conversation select. Defaults to 'Select conversation'. */
+	selectLabel?: string;
+	/** Label for the new conversation button. Defaults to 'New conversation'. */
+	newLabel?: string;
+	/** Label for the delete button. Defaults to 'Delete'. */
+	deleteLabel?: string;
+	/** Accessible label for the delete button. Defaults to 'Delete selected conversation'. */
+	deleteAriaLabel?: string;
+	/** Label shown while sessions load. Defaults to 'Loading...'. */
+	loadingLabel?: string;
 	/** Additional CSS class name. */
 	className?: string;
 }
@@ -29,6 +41,12 @@ export function SessionSwitcher({
 	onNew,
 	onDelete,
 	loading = false,
+	title = 'Conversations',
+	selectLabel = 'Select conversation',
+	newLabel = 'New conversation',
+	deleteLabel = 'Delete',
+	deleteAriaLabel = 'Delete selected conversation',
+	loadingLabel = 'Loading...',
 	className,
 }: SessionSwitcherProps) {
 	const baseClass = 'ec-chat-sessions';
@@ -38,12 +56,12 @@ export function SessionSwitcher({
 	return (
 		<div className={classes}>
 			<div className={`${baseClass}__header`}>
-				<span className={`${baseClass}__title`}>Conversations</span>
+				<span className={`${baseClass}__title`}>{title}</span>
 				{onNew && (
 					<button
 						className={`${baseClass}__new`}
 						onClick={onNew}
-						aria-label="New conversation"
+						aria-label={newLabel}
 						type="button"
 					>
 						+
@@ -51,12 +69,12 @@ export function SessionSwitcher({
 				)}
 			</div>
 
-			{loading && <div className={`${baseClass}__loading`}>Loading...</div>}
+			{loading && <div className={`${baseClass}__loading`}>{loadingLabel}</div>}
 
 			{sessions.length > 0 && (
 				<div className={`${baseClass}__controls`}>
 					<label className={`${baseClass}__select-wrap`}>
-						<span className="ec-chat-sr-only">Select conversation</span>
+						<span className="ec-chat-sr-only">{selectLabel}</span>
 						<select
 							className={`${baseClass}__select`}
 							value={currentSessionId}
@@ -75,10 +93,10 @@ export function SessionSwitcher({
 						<button
 							className={`${baseClass}__delete`}
 							onClick={() => onDelete(currentSessionId)}
-							aria-label="Delete selected conversation"
+							aria-label={deleteAriaLabel}
 							type="button"
 						>
-							Delete
+							{deleteLabel}
 						</button>
 					)}
 				</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,12 @@ export {
 } from './components/SessionSwitcher.tsx';
 
 export {
+	AgentSwitcher,
+	type AgentSwitcherAgent,
+	type AgentSwitcherProps,
+} from './components/AgentSwitcher.tsx';
+
+export {
 	ErrorBoundary,
 	type ErrorBoundaryProps,
 } from './components/ErrorBoundary.tsx';


### PR DESCRIPTION
## Summary
- Add configurable labels to the built-in `SessionSwitcher` and `Chat` session switcher props instead of hardcoding `Conversations`.
- Add a reusable generic `AgentSwitcher` primitive for consumers that need agent selection UI.
- Add base CSS hooks for the generic agent switcher.

## Testing
- `npm install`
- `npm run build`
- `homeboy lint --path . --extension nodejs`
- `homeboy test --path . --extension nodejs` (runner reports `No package.json found at or above .`; package-level build was used as the effective check)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified hardcoded switcher labels, drafted the reusable component/props, and ran local verification. Chris remains responsible for review and acceptance.