### PR TITLE
Place typing indicator in message flow

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 import type { ChatMessage as ChatMessageType, ContentFormat, ToolCall } from './types/index.ts';
 import type { FetchFn, MediaUploadFn } from './api.ts';
 import type { ToolGroup } from './components/ToolMessage.tsx';
@@ -257,9 +257,24 @@ export function Chat({
 		chat.isLoading && !!loadingMessagesConfig,
 		loadingMessagesConfig,
 	);
+	const hasLoadingMessages = !!loadingMessagesConfig;
 
 	const baseClass = 'ec-chat';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const typingIndicator = useMemo(() => (
+		<TypingIndicator
+			visible={chat.isLoading}
+			label={
+				chat.turnCount > 0
+					? (processingLabel
+						? processingLabel(chat.turnCount)
+						: `Processing turn ${chat.turnCount}...`)
+					: hasLoadingMessages
+						? cycling.message
+						: undefined
+			}
+		/>
+	), [chat.isLoading, chat.turnCount, processingLabel, hasLoadingMessages, cycling.message]);
 
 	return (
 		<ErrorBoundary onError={onError ? (err) => onError(err) : undefined}>
@@ -286,20 +301,8 @@ export function Chat({
 					toolNames={toolNames}
 					toolRenderers={toolRenderers}
 					emptyState={emptyState}
+					footer={typingIndicator}
 				/>
-
-					<TypingIndicator
-						visible={chat.isLoading}
-						label={
-							chat.turnCount > 0
-								? (processingLabel
-									? processingLabel(chat.turnCount)
-									: `Processing turn ${chat.turnCount}...`)
-								: loadingMessagesConfig
-									? cycling.message
-									: undefined
-						}
-					/>
 
 					<ChatInput
 						onSend={chat.sendMessage}

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -34,6 +34,8 @@ export interface ChatMessagesProps {
 	autoScroll?: boolean;
 	/** Placeholder content shown when there are no messages. */
 	emptyState?: ReactNode;
+	/** Content rendered at the end of the message flow before the scroll anchor. */
+	footer?: ReactNode;
 	/** Additional CSS class name. */
 	className?: string;
 }
@@ -53,6 +55,7 @@ export function ChatMessages({
 	toolRenderers,
 	autoScroll = true,
 	emptyState,
+	footer,
 	className,
 }: ChatMessagesProps) {
 	const bottomRef = useRef<HTMLDivElement>(null);
@@ -67,7 +70,7 @@ export function ChatMessages({
 			top: container.scrollHeight,
 			behavior: 'smooth',
 		});
-	}, [messages, autoScroll]);
+	}, [messages, footer, autoScroll]);
 
 	const displayItems = buildDisplayItems(messages, showTools);
 	const baseClass = 'ec-chat-messages';
@@ -79,6 +82,8 @@ export function ChatMessages({
 				<div className={`${baseClass}__empty`}>
 					{emptyState}
 				</div>
+				{footer}
+				<div ref={bottomRef} />
 			</div>
 		);
 	}
@@ -118,6 +123,7 @@ export function ChatMessages({
 
 				return null;
 			})}
+			{footer}
 			<div ref={bottomRef} />
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Render the typing indicator inside the scrollable message list where the next assistant message will appear.
- Add a small `footer` slot to `ChatMessages` so pending UI can participate in message-flow scrolling.
- Keep the input pinned below the transcript instead of treating typing state as an input-adjacent control.

## Testing
- `npm install`
- `npm run build`
- `homeboy lint --path . --extension nodejs`
- `homeboy test --path . --extension nodejs` (runner reports `No package.json found at or above .`; package-level build was used as the effective check)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed typing indicator placement, drafted the message-flow footer patch, and ran local verification. Chris remains responsible for review and acceptance.