### PR TITLE
Fix chat sizing in bounded containers

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -76,6 +76,8 @@
 	flex-direction: column;
 	max-width: var(--ec-chat-max-width);
 	height: 100%;
+	min-width: 0;
+	min-height: 0;
 }
 
 /* ============================================
@@ -179,7 +181,9 @@
    ============================================ */
 
 .ec-chat-messages {
-	flex: 1;
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 0;
 	overflow-y: auto;
 	padding: var(--ec-chat-padding);
 	display: flex;


### PR DESCRIPTION
## Summary
- Allow the chat root to shrink inside bounded flex containers.
- Let the message pane own vertical overflow instead of forcing parent viewport shells to grow.

## Testing
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the chat package layout constraints, drafted the CSS fix, and ran verification. Chris remains responsible for review and merge.