### PR TITLE
Load default chat session messages

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -220,6 +220,7 @@ export function useChat({
 	sessionContextRef.current = sessionContext;
 	// Guard against concurrent session creation.
 	const isCreatingRef = useRef(false);
+	const hasInitialMessagesRef = useRef((initialMessages?.length ?? 0) > 0);
 
 	// Load sessions on mount
 	useEffect(() => {
@@ -232,6 +233,15 @@ export function useChat({
 					sessionContextRef.current,
 				);
 				setSessions(list);
+
+				const defaultSessionId = sessionIdRef.current ?? list[0]?.id ?? null;
+				if (defaultSessionId && !hasInitialMessagesRef.current) {
+					setSessionId(defaultSessionId);
+					sessionIdRef.current = defaultSessionId;
+
+					const loaded = await apiLoadSession(configRef.current, defaultSessionId);
+					setMessages(loaded);
+				}
 			} catch (err) {
 				// Sessions not available — degrade gracefully
 				onError?.(toError(err));


### PR DESCRIPTION
## Summary
- Load the active/default session transcript after the session list is fetched.
- Keep existing `initialMessages` hydration behavior intact by skipping automatic session loading when initial messages are supplied.
- Align hook state with the session switcher, which already visually defaults to the first session when no active session is set.

## Testing
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the session hydration bug, drafted the hook fix, and ran build verification for Chris to review.