### PR TITLE
Remove redundant typing indicator padding

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -431,7 +431,6 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 4px var(--ec-chat-padding);
 	max-height: var(--ec-chat-typing-max-height, 96px);
 	opacity: 1;
 	overflow: visible;


### PR DESCRIPTION
## Summary
- Remove the extra horizontal padding from the typing indicator so it uses the message container gutter.

## Testing
- Not run; CSS-only one-line cleanup.