### PR TITLE
Expose chat response metadata

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -68,6 +68,8 @@ export interface ChatProps {
 	 * mutates server state).
 	 */
 	onToolCalls?: (toolCalls: ToolCall[]) => void;
+	/** Called with response-level metadata returned by the backend. */
+	onResponseMetadata?: UseChatOptions['onResponseMetadata'];
 	/**
 	 * Session-list scope filter passed to the backend.
 	 *
@@ -199,6 +201,7 @@ export function Chat({
 	onError,
 	onMessage,
 	onToolCalls,
+	onResponseMetadata,
 	sessionContext,
 	className,
 	showSessions = true,
@@ -231,6 +234,7 @@ export function Chat({
 		onError,
 		onMessage,
 		onToolCalls,
+		onResponseMetadata,
 		sessionContext,
 		metadata,
 		mediaUploadFn,

--- a/src/api.ts
+++ b/src/api.ts
@@ -53,6 +53,7 @@ export interface ChatApiConfig {
 export interface SendResult {
 	sessionId: string;
 	messages: ChatMessage[];
+	metadata: Record<string, unknown>;
 	completed: boolean;
 	turnNumber: number;
 	maxTurnsReached: boolean;
@@ -60,6 +61,7 @@ export interface SendResult {
 
 export interface ContinueResult {
 	messages: ChatMessage[];
+	metadata: Record<string, unknown>;
 	completed: boolean;
 	turnNumber: number;
 	maxTurnsReached: boolean;
@@ -139,6 +141,7 @@ export async function sendMessage(
 	return {
 		sessionId: raw.data.session_id,
 		messages: normalizeConversation(raw.data.conversation),
+		metadata: raw.data.metadata ?? {},
 		completed: raw.data.completed,
 		turnNumber: raw.data.turn_number,
 		maxTurnsReached: raw.data.max_turns_reached,
@@ -164,6 +167,7 @@ export async function continueResponse(
 
 	return {
 		messages: raw.data.new_messages.map(normalizeMessage),
+		metadata: raw.data.metadata ?? {},
 		completed: raw.data.completed,
 		turnNumber: raw.data.turn_number,
 		maxTurnsReached: raw.data.max_turns_reached,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -58,6 +58,8 @@ export interface UseChatOptions {
 	 * apply diffs to the editor, update external state).
 	 */
 	onToolCalls?: (toolCalls: ToolCall[]) => void;
+	/** Called with response-level metadata returned by the backend. */
+	onResponseMetadata?: (metadata: Record<string, unknown>) => void;
 	/**
 	 * Arbitrary metadata forwarded to the backend with each message.
 	 * Use for context scoping (e.g. `{ selected_pipeline_id: 42 }`,
@@ -184,6 +186,7 @@ export function useChat({
 	onMessage,
 	onError,
 	onToolCalls,
+	onResponseMetadata,
 	metadata,
 	mediaUploadFn,
 	sessionContext,
@@ -212,6 +215,8 @@ export function useChat({
 	// Refs for latest callback/metadata values (avoid stale closures).
 	const onToolCallsRef = useRef(onToolCalls);
 	onToolCallsRef.current = onToolCalls;
+	const onResponseMetadataRef = useRef(onResponseMetadata);
+	onResponseMetadataRef.current = onResponseMetadata;
 	const metadataRef = useRef(metadata);
 	metadataRef.current = metadata;
 	const mediaUploadFnRef = useRef(mediaUploadFn);
@@ -359,6 +364,7 @@ export function useChat({
 
 			// Replace all messages with the full normalized conversation
 			setMessages(result.messages);
+			onResponseMetadataRef.current?.(result.metadata);
 
 			// Fire tool call callback for the initial response.
 			fireToolCalls(result.messages);
@@ -378,6 +384,7 @@ export function useChat({
 					);
 
 					setMessages((prev) => [...prev, ...continuation.messages]);
+					onResponseMetadataRef.current?.(continuation.metadata);
 					for (const msg of continuation.messages) {
 						onMessage?.(msg);
 					}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -73,7 +73,7 @@ export interface SendResponse {
 			parameters: Record<string, unknown>;
 		}>;
 		conversation: RawMessage[];
-		metadata: SessionMetadata;
+		metadata: Record<string, unknown>;
 		completed: boolean;
 		max_turns: number;
 		turn_number: number;
@@ -103,6 +103,7 @@ export interface ContinueResponse {
 		turn_number: number;
 		max_turns: number;
 		max_turns_reached: boolean;
+		metadata?: Record<string, unknown>;
 	};
 }
 


### PR DESCRIPTION
## Summary
- preserve response-level metadata from chat send/continue responses
- expose the metadata through a new Chat/useChat callback for domain-specific consumers
- widen REST response metadata typing for open-ended payloads

## Verification
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the metadata callback API and ran local TypeScript verification; Chris remains responsible for review and testing.