### PR TITLE
Add chat message suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ Override CSS custom properties on `.ec-chat` to match your design system:
 }
 ```
 
+## Message Suggestions
+
+Pass `messageSuggestions` to offer optional prompt starters on fresh conversations. Selecting one sends its `message`, or its `label` when `message` is omitted.
+
+```tsx
+<Chat
+  basePath="/datamachine/v1/chat"
+  fetchFn={apiFetch}
+  messageSuggestions={[
+    {
+      label: 'Plan my homepage',
+      message: 'Help me plan the homepage for my site.',
+      description: 'Start with goals and sections',
+    },
+    {
+      label: 'Write an about page',
+      message: 'Help me draft a friendly about page.',
+    },
+  ]}
+/>
+```
+
 ## Consumers
 
 - **extrachill-studio** — Studio Chat tab (agent_id=5)

--- a/css/chat.css
+++ b/css/chat.css
@@ -210,6 +210,59 @@
 	padding: 32px;
 }
 
+.ec-chat__empty-with-suggestions {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 20px;
+	width: min(100%, 520px);
+}
+
+.ec-chat-suggestions {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	gap: 8px;
+	width: 100%;
+}
+
+.ec-chat-suggestions__item {
+	appearance: none;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 12px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text);
+	cursor: pointer;
+	font: inherit;
+	padding: 10px 12px;
+	text-align: left;
+	transition: background-color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.ec-chat-suggestions__item:hover:not(:disabled) {
+	background: var(--ec-chat-session-hover-bg);
+	border-color: var(--ec-chat-input-focus-border);
+}
+
+.ec-chat-suggestions__item:disabled {
+	cursor: not-allowed;
+	opacity: var(--ec-chat-send-disabled-opacity);
+}
+
+.ec-chat-suggestions__label,
+.ec-chat-suggestions__description {
+	display: block;
+}
+
+.ec-chat-suggestions__label {
+	font-weight: 600;
+}
+
+.ec-chat-suggestions__description {
+	color: var(--ec-chat-text-muted);
+	font-size: 12px;
+	margin-top: 4px;
+}
+
 /* ============================================
    Individual Message
    ============================================ */

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -10,6 +10,7 @@ import { ChatMessages } from './components/ChatMessages.tsx';
 import { ChatInput } from './components/ChatInput.tsx';
 import { TypingIndicator } from './components/TypingIndicator.tsx';
 import { SessionSwitcher } from './components/SessionSwitcher.tsx';
+import { MessageSuggestions, type ChatMessageSuggestion } from './components/MessageSuggestions.tsx';
 import type { UseChatReturn } from './hooks/useChat.ts';
 
 export type ChatSessionUi = 'list' | 'none';
@@ -49,6 +50,10 @@ export interface ChatProps {
 	placeholder?: string;
 	/** Content shown when conversation is empty. */
 	emptyState?: ReactNode;
+	/** Suggested messages shown when the conversation is empty. */
+	messageSuggestions?: ChatMessageSuggestion[];
+	/** Accessible label for suggested messages. */
+	messageSuggestionsLabel?: string;
 	/** Initial messages (hydrated from server). */
 	initialMessages?: ChatMessageType[];
 	/** Initial session ID. */
@@ -195,6 +200,8 @@ export function Chat({
 	toolRenderers,
 	placeholder,
 	emptyState,
+	messageSuggestions,
+	messageSuggestionsLabel,
 	initialMessages,
 	initialSessionId,
 	maxContinueTurns,
@@ -271,6 +278,20 @@ export function Chat({
 
 	const baseClass = 'ec-chat';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const resolvedMessageSuggestions = messageSuggestions ?? [];
+	const hasVisibleMessages = chat.messages.some((message) => message.role !== 'system');
+	const showMessageSuggestions = resolvedMessageSuggestions.length > 0 && !hasVisibleMessages;
+	const resolvedEmptyState = showMessageSuggestions ? (
+		<div className={`${baseClass}__empty-with-suggestions`}>
+			{emptyState}
+			<MessageSuggestions
+				suggestions={resolvedMessageSuggestions}
+				onSelect={(suggestion) => chat.sendMessage(suggestion.message ?? suggestion.label)}
+				label={messageSuggestionsLabel}
+				disabled={chat.isLoading}
+			/>
+		</div>
+	) : emptyState;
 	const typingIndicator = useMemo(() => (
 		<TypingIndicator
 			visible={chat.isLoading}
@@ -312,7 +333,7 @@ export function Chat({
 					showTools={showTools}
 					toolNames={toolNames}
 					toolRenderers={toolRenderers}
-					emptyState={emptyState}
+					emptyState={resolvedEmptyState}
 					footer={typingIndicator}
 				/>
 

--- a/src/components/MessageSuggestions.tsx
+++ b/src/components/MessageSuggestions.tsx
@@ -1,0 +1,58 @@
+export interface ChatMessageSuggestion {
+	/** Short visible suggestion label. */
+	label: string;
+	/** Message sent when selected. Defaults to the label. */
+	message?: string;
+	/** Optional supporting text shown under the label. */
+	description?: string;
+}
+
+export interface MessageSuggestionsProps {
+	/** Suggestions to offer. */
+	suggestions: ChatMessageSuggestion[];
+	/** Called when a suggestion is selected. */
+	onSelect: (suggestion: ChatMessageSuggestion) => void;
+	/** Accessible label for the suggestion group. */
+	label?: string;
+	/** Whether suggestion buttons are disabled. */
+	disabled?: boolean;
+	/** Additional CSS class name. */
+	className?: string;
+}
+
+/**
+ * Optional prompt starters for fresh conversations.
+ */
+export function MessageSuggestions({
+	suggestions,
+	onSelect,
+	label = 'Suggested messages',
+	disabled = false,
+	className,
+}: MessageSuggestionsProps) {
+	if (suggestions.length === 0) {
+		return null;
+	}
+
+	const baseClass = 'ec-chat-suggestions';
+	const classes = [baseClass, className].filter(Boolean).join(' ');
+
+	return (
+		<div className={classes} role="group" aria-label={label}>
+			{suggestions.map((suggestion, index) => (
+				<button
+					key={`${suggestion.label}-${index}`}
+					className={`${baseClass}__item`}
+					type="button"
+					onClick={() => onSelect(suggestion)}
+					disabled={disabled}
+				>
+					<span className={`${baseClass}__label`}>{suggestion.label}</span>
+					{suggestion.description && (
+						<span className={`${baseClass}__description`}>{suggestion.description}</span>
+					)}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,5 +5,6 @@ export { ToolMessage, type ToolMessageProps, type ToolGroup } from './ToolMessag
 export { DiffCard, type DiffCardProps, type DiffData } from './DiffCard.tsx';
 export { TypingIndicator, type TypingIndicatorProps } from './TypingIndicator.tsx';
 export { SessionSwitcher, type SessionSwitcherProps } from './SessionSwitcher.tsx';
+export { MessageSuggestions, type ChatMessageSuggestion, type MessageSuggestionsProps } from './MessageSuggestions.tsx';
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.tsx';
 export { AvailabilityGate, type AvailabilityGateProps } from './AvailabilityGate.tsx';

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,12 @@ export {
 } from './components/SessionSwitcher.tsx';
 
 export {
+	MessageSuggestions,
+	type ChatMessageSuggestion,
+	type MessageSuggestionsProps,
+} from './components/MessageSuggestions.tsx';
+
+export {
 	AgentSwitcher,
 	type AgentSwitcherAgent,
 	type AgentSwitcherProps,


### PR DESCRIPTION
## Summary
- Add a generic MessageSuggestions primitive for starter prompts.
- Add optional Chat props for fresh-session message suggestions.
- Document the messageSuggestions API and add base styles.

## Testing
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the component, Chat wiring, CSS, README docs, and local build verification; Chris reviewed the product direction.