### PR TITLE
feat: add question tool card

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -264,6 +264,115 @@
 }
 
 /* ============================================
+   Question Card
+   ============================================ */
+
+.ec-chat-question {
+	align-self: flex-start;
+	width: min(100%, 520px);
+	border: 1px solid var(--ec-chat-border);
+	border-radius: var(--ec-chat-border-radius);
+	background: var(--ec-chat-assistant-bg);
+	color: var(--ec-chat-assistant-text);
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.ec-chat-question__prompt {
+	font-weight: 600;
+}
+
+.ec-chat-question__choices {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	gap: 8px;
+}
+
+.ec-chat-question__choice {
+	appearance: none;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 10px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text);
+	cursor: pointer;
+	font: inherit;
+	padding: 10px 12px;
+	text-align: left;
+	transition: background-color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.ec-chat-question__choice:hover:not(:disabled) {
+	background: var(--ec-chat-session-hover-bg);
+	border-color: var(--ec-chat-input-focus-border);
+}
+
+.ec-chat-question__choice:disabled,
+.ec-chat-question__freeform-submit:disabled,
+.ec-chat-question__freeform-input:disabled {
+	cursor: not-allowed;
+	opacity: var(--ec-chat-send-disabled-opacity);
+}
+
+.ec-chat-question__choice-label,
+.ec-chat-question__choice-description {
+	display: block;
+}
+
+.ec-chat-question__choice-label {
+	font-weight: 600;
+}
+
+.ec-chat-question__choice-description {
+	color: var(--ec-chat-text-muted);
+	font-size: 12px;
+	margin-top: 4px;
+}
+
+.ec-chat-question__freeform {
+	display: flex;
+	gap: 8px;
+	align-items: flex-end;
+}
+
+.ec-chat-question__freeform-label {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+	color: var(--ec-chat-text-muted);
+}
+
+.ec-chat-question__freeform-input {
+	border: 1px solid var(--ec-chat-input-border);
+	border-radius: 999px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text);
+	font: inherit;
+	font-size: var(--ec-chat-font-size);
+	padding: 8px 12px;
+}
+
+.ec-chat-question__freeform-input:focus {
+	border-color: var(--ec-chat-input-focus-border);
+	outline: none;
+}
+
+.ec-chat-question__freeform-submit {
+	appearance: none;
+	border: 0;
+	border-radius: 999px;
+	background: var(--ec-chat-send-bg);
+	color: var(--ec-chat-send-text);
+	cursor: pointer;
+	font: inherit;
+	font-weight: 600;
+	padding: 8px 14px;
+}
+
+/* ============================================
    Individual Message
    ============================================ */
 

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 import type { ChatMessage as ChatMessageType, ContentFormat, ToolCall } from './types/index.ts';
 import type { FetchFn, MediaUploadFn } from './api.ts';
-import type { ToolGroup } from './components/ToolMessage.tsx';
+import type { ToolRenderer } from './components/ToolMessage.tsx';
 import { useChat, type UseChatOptions } from './hooks/useChat.ts';
 import { useLoadingMessages, type LoadingMessagesConfig } from './hooks/useLoadingMessages.ts';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
@@ -45,7 +45,7 @@ export interface ChatProps {
 	 * matches a registered name, the custom renderer is used instead of
 	 * the default ToolMessage JSON display.
 	 */
-	toolRenderers?: Record<string, (group: ToolGroup) => ReactNode>;
+	toolRenderers?: Record<string, ToolRenderer>;
 	/** Placeholder text for the input. */
 	placeholder?: string;
 	/** Content shown when conversation is empty. */
@@ -333,6 +333,10 @@ export function Chat({
 					showTools={showTools}
 					toolNames={toolNames}
 					toolRenderers={toolRenderers}
+					toolRendererContext={{
+						sendMessage: chat.sendMessage,
+						isLoading: chat.isLoading,
+					}}
 					emptyState={resolvedEmptyState}
 					footer={typingIndicator}
 				/>

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import type { ChatMessage as ChatMessageType, ContentFormat } from '../types/index.ts';
 import { ChatMessage } from './ChatMessage.tsx';
-import { ToolMessage, type ToolGroup } from './ToolMessage.tsx';
+import { ToolMessage, type ToolGroup, type ToolRenderer, type ToolRendererContext } from './ToolMessage.tsx';
 
 export interface ChatMessagesProps {
 	/** All messages in the conversation. */
@@ -29,7 +29,9 @@ export interface ChatMessagesProps {
 	 * }}
 	 * ```
 	 */
-	toolRenderers?: Record<string, (group: ToolGroup) => ReactNode>;
+	toolRenderers?: Record<string, ToolRenderer>;
+	/** Action context passed to custom tool renderers. */
+	toolRendererContext?: ToolRendererContext;
 	/** Whether to auto-scroll to bottom on new messages. Defaults to true. */
 	autoScroll?: boolean;
 	/** Placeholder content shown when there are no messages. */
@@ -53,6 +55,7 @@ export function ChatMessages({
 	showTools = false,
 	toolNames,
 	toolRenderers,
+	toolRendererContext,
 	autoScroll = true,
 	emptyState,
 	footer,
@@ -75,6 +78,10 @@ export function ChatMessages({
 	const displayItems = buildDisplayItems(messages, showTools);
 	const baseClass = 'ec-chat-messages';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const rendererContext = toolRendererContext ?? {
+		sendMessage: () => {},
+		isLoading: false,
+	};
 
 	if (displayItems.length === 0 && emptyState) {
 		return (
@@ -107,7 +114,7 @@ export function ChatMessages({
 					if (customRenderer) {
 						return (
 							<div key={item.group.callMessage.id}>
-								{customRenderer(item.group)}
+								{customRenderer(item.group, rendererContext)}
 							</div>
 						);
 					}

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,0 +1,98 @@
+import { useState, type FormEvent } from 'react';
+
+export interface QuestionChoice {
+	/** Short visible choice label. */
+	label: string;
+	/** Message sent when selected. Defaults to the label. */
+	message?: string;
+	/** Optional supporting text shown under the label. */
+	description?: string;
+}
+
+export interface QuestionCardProps {
+	/** Question to ask the user. */
+	question: string;
+	/** Model-proposed choices. */
+	choices?: QuestionChoice[];
+	/** Whether the user may type a custom answer. Defaults to true. */
+	allowFreeform?: boolean;
+	/** Label for the freeform answer input. */
+	freeformLabel?: string;
+	/** Placeholder for the freeform answer input. */
+	freeformPlaceholder?: string;
+	/** Called with the selected or typed answer. */
+	onSubmitAnswer: (answer: string) => void;
+	/** Whether controls are disabled. */
+	disabled?: boolean;
+	/** Additional CSS class name. */
+	className?: string;
+}
+
+/**
+ * Renders a structured model-proposed question with selectable choices and
+ * an optional custom-answer input.
+ */
+export function QuestionCard({
+	question,
+	choices = [],
+	allowFreeform = true,
+	freeformLabel = 'Type your own answer',
+	freeformPlaceholder = 'Type your answer...',
+	onSubmitAnswer,
+	disabled = false,
+	className,
+}: QuestionCardProps) {
+	const [freeformAnswer, setFreeformAnswer] = useState('');
+	const baseClass = 'ec-chat-question';
+	const classes = [baseClass, className].filter(Boolean).join(' ');
+
+	function handleSubmit(event: FormEvent) {
+		event.preventDefault();
+		const answer = freeformAnswer.trim();
+		if (!answer || disabled) return;
+		onSubmitAnswer(answer);
+		setFreeformAnswer('');
+	}
+
+	return (
+		<div className={classes}>
+			<div className={`${baseClass}__prompt`}>{question}</div>
+			{choices.length > 0 && (
+				<div className={`${baseClass}__choices`} role="group" aria-label={question}>
+					{choices.map((choice, index) => (
+						<button
+							key={`${choice.label}-${index}`}
+							className={`${baseClass}__choice`}
+							type="button"
+							onClick={() => onSubmitAnswer(choice.message ?? choice.label)}
+							disabled={disabled}
+						>
+							<span className={`${baseClass}__choice-label`}>{choice.label}</span>
+							{choice.description && (
+								<span className={`${baseClass}__choice-description`}>{choice.description}</span>
+							)}
+						</button>
+					))}
+				</div>
+			)}
+			{allowFreeform && (
+				<form className={`${baseClass}__freeform`} onSubmit={handleSubmit}>
+					<label className={`${baseClass}__freeform-label`}>
+						{freeformLabel}
+						<input
+							className={`${baseClass}__freeform-input`}
+							type="text"
+							value={freeformAnswer}
+							onChange={(event) => setFreeformAnswer(event.target.value)}
+							placeholder={freeformPlaceholder}
+							disabled={disabled}
+						/>
+					</label>
+					<button className={`${baseClass}__freeform-submit`} type="submit" disabled={disabled || !freeformAnswer.trim()}>
+						Send
+					</button>
+				</form>
+			)}
+		</div>
+	);
+}

--- a/src/components/ToolMessage.tsx
+++ b/src/components/ToolMessage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import type { ChatMessage } from '../types/index.ts';
 
 /**
@@ -16,6 +17,15 @@ export interface ToolGroup {
 	/** Whether the tool succeeded (null if pending). */
 	success: boolean | null;
 }
+
+export interface ToolRendererContext {
+	/** Send a follow-up user message. */
+	sendMessage: (content: string) => void;
+	/** Whether chat is currently processing a request. */
+	isLoading: boolean;
+}
+
+export type ToolRenderer = (group: ToolGroup, context: ToolRendererContext) => ReactNode;
 
 export interface ToolMessageProps {
 	/** The tool call/result group to display. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,15 @@ export {
 	ToolMessage,
 	type ToolMessageProps,
 	type ToolGroup,
+	type ToolRenderer,
+	type ToolRendererContext,
 } from './components/ToolMessage.tsx';
+
+export {
+	QuestionCard,
+	type QuestionCardProps,
+	type QuestionChoice,
+} from './components/QuestionCard.tsx';
 
 export {
 	DiffCard,


### PR DESCRIPTION
## Summary
- Add a reusable `QuestionCard` component for structured follow-up questions.
- Pass `sendMessage` and loading state into custom tool renderers.
- Add shared styles for selectable answer cards and freeform replies.

## Testing
- `npm run build`
- `homeboy audit --path /Users/chubes/Developer/chat --extension nodejs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the question-card component, renderer context plumbing, styles, and verification commands for Chris to review/test.
