### PR TITLE
fix: render question cards after assistant replies

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -150,6 +150,12 @@ type DisplayItem =
 function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): DisplayItem[] {
 	const items: DisplayItem[] = [];
 	const toolResultMap = new Map<string, ChatMessageType>();
+	const pendingStandaloneToolGroups: DisplayItem[] = [];
+	const flushPendingStandaloneTools = () => {
+		if (pendingStandaloneToolGroups.length === 0) return;
+		items.push(...pendingStandaloneToolGroups);
+		pendingStandaloneToolGroups.length = 0;
+	};
 
 	// Pre-index tool results by tool name for pairing
 	if (showTools) {
@@ -171,6 +177,12 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 
 		// Handle user/assistant messages (assistant messages with toolCalls get both treatments)
 		if (msg.role === 'user' || msg.role === 'assistant') {
+			// Standalone tool envelopes often precede the assistant's follow-up text.
+			// Keep their rendered cards attached to that response instead of jumping above it.
+			if (msg.role === 'user') {
+				flushPendingStandaloneTools();
+			}
+
 			// If assistant message has tool calls, render the text part as a message
 			// and the tool calls as tool groups
 			if (msg.role === 'assistant' && msg.toolCalls?.length && showTools) {
@@ -203,6 +215,10 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 			} else {
 				items.push({ type: 'message', message: msg });
 			}
+
+			if (msg.role === 'assistant') {
+				flushPendingStandaloneTools();
+			}
 			continue;
 		}
 
@@ -214,7 +230,7 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 				processedToolResults.add(resultMsg.id);
 			}
 
-			items.push({
+			pendingStandaloneToolGroups.push({
 				type: 'tool-group',
 				group: {
 					callMessage: msg,
@@ -229,6 +245,7 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 
 		// Handle orphaned tool_result messages
 		if (msg.role === 'tool_result' && showTools && !processedToolResults.has(msg.id)) {
+			flushPendingStandaloneTools();
 			items.push({
 				type: 'tool-group',
 				group: {
@@ -241,6 +258,8 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 			});
 		}
 	}
+
+	flushPendingStandaloneTools();
 
 	return items;
 }

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -24,6 +24,8 @@ export interface QuestionCardProps {
 	onSubmitAnswer: (answer: string) => void;
 	/** Whether controls are disabled. */
 	disabled?: boolean;
+	/** Hide the card after the user submits an answer. Defaults to true. */
+	autoHideOnSubmit?: boolean;
 	/** Additional CSS class name. */
 	className?: string;
 }
@@ -40,18 +42,33 @@ export function QuestionCard({
 	freeformPlaceholder = 'Type your answer...',
 	onSubmitAnswer,
 	disabled = false,
+	autoHideOnSubmit = true,
 	className,
 }: QuestionCardProps) {
 	const [freeformAnswer, setFreeformAnswer] = useState('');
+	const [submitted, setSubmitted] = useState(false);
 	const baseClass = 'ec-chat-question';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const controlsDisabled = disabled || submitted;
+
+	function submitAnswer(answer: string) {
+		if (!answer.trim() || controlsDisabled) return;
+		onSubmitAnswer(answer);
+		if (autoHideOnSubmit) {
+			setSubmitted(true);
+		}
+	}
 
 	function handleSubmit(event: FormEvent) {
 		event.preventDefault();
 		const answer = freeformAnswer.trim();
-		if (!answer || disabled) return;
-		onSubmitAnswer(answer);
+		if (!answer || controlsDisabled) return;
+		submitAnswer(answer);
 		setFreeformAnswer('');
+	}
+
+	if (submitted && autoHideOnSubmit) {
+		return null;
 	}
 
 	return (
@@ -64,8 +81,8 @@ export function QuestionCard({
 							key={`${choice.label}-${index}`}
 							className={`${baseClass}__choice`}
 							type="button"
-							onClick={() => onSubmitAnswer(choice.message ?? choice.label)}
-							disabled={disabled}
+							onClick={() => submitAnswer(choice.message ?? choice.label)}
+							disabled={controlsDisabled}
 						>
 							<span className={`${baseClass}__choice-label`}>{choice.label}</span>
 							{choice.description && (
@@ -85,10 +102,10 @@ export function QuestionCard({
 							value={freeformAnswer}
 							onChange={(event) => setFreeformAnswer(event.target.value)}
 							placeholder={freeformPlaceholder}
-							disabled={disabled}
+							disabled={controlsDisabled}
 						/>
 					</label>
-					<button className={`${baseClass}__freeform-submit`} type="submit" disabled={disabled || !freeformAnswer.trim()}>
+					<button className={`${baseClass}__freeform-submit`} type="submit" disabled={controlsDisabled || !freeformAnswer.trim()}>
 						Send
 					</button>
 				</form>


### PR DESCRIPTION
## Summary
- Render standalone tool cards after the assistant follow-up response instead of above it.
- Hide question cards locally after an answer is submitted so users cannot click the same prompt twice.

## Testing
- `npm run build`
- `homeboy audit --path /Users/chubes/Developer/chat --extension nodejs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed and drafted the question-card ordering and one-shot submission behavior for Chris to review/test.
