### PR TITLE
fix: pair tool results by call id

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -160,8 +160,8 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 	// Pre-index tool results by tool name for pairing
 	if (showTools) {
 		for (const msg of messages) {
-			if (msg.role === 'tool_result' && msg.toolResult?.toolName) {
-				toolResultMap.set(msg.toolResult.toolName, msg);
+			if (msg.role === 'tool_result' && msg.toolResult) {
+				toolResultMap.set(toolResultKey(msg.toolResult.toolCallId, msg.toolResult.toolName), msg);
 			}
 		}
 	}
@@ -192,7 +192,7 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 				}
 
 				for (const call of msg.toolCalls) {
-					const resultMsg = toolResultMap.get(call.name);
+					const resultMsg = toolResultMap.get(toolResultKey(call.id, call.name));
 					if (resultMsg) {
 						processedToolResults.add(resultMsg.id);
 					}
@@ -225,7 +225,8 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 		// Handle standalone tool_call messages
 		if (msg.role === 'tool_call' && showTools) {
 			const toolName = msg.toolCalls?.[0]?.name ?? 'unknown';
-			const resultMsg = toolResultMap.get(toolName);
+			const toolCallId = msg.toolCalls?.[0]?.id;
+			const resultMsg = toolResultMap.get(toolResultKey(toolCallId, toolName));
 			if (resultMsg) {
 				processedToolResults.add(resultMsg.id);
 			}
@@ -262,4 +263,8 @@ function buildDisplayItems(messages: ChatMessageType[], showTools: boolean): Dis
 	flushPendingStandaloneTools();
 
 	return items;
+}
+
+function toolResultKey(toolCallId: string | undefined, toolName: string): string {
+	return toolCallId ? `id:${toolCallId}` : `name:${toolName}`;
 }

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -25,11 +25,14 @@ export function normalizeMessage(raw: RawMessage, index: number): ChatMessage {
 
 	if (type === 'tool_call') {
 		const toolCalls: ToolCall[] = [];
+		const metadataToolCallId = typeof raw.metadata?.tool_call_id === 'string' && raw.metadata.tool_call_id
+			? raw.metadata.tool_call_id
+			: null;
 
 		// Extract from metadata (single tool call)
 		if (raw.metadata?.tool_name) {
 			toolCalls.push({
-				id: `tc_${index}_${raw.metadata.tool_name}`,
+				id: metadataToolCallId ?? `tc_${index}_${raw.metadata.tool_name}`,
 				name: raw.metadata.tool_name,
 				parameters: raw.metadata.parameters ?? {},
 			});
@@ -39,9 +42,9 @@ export function normalizeMessage(raw: RawMessage, index: number): ChatMessage {
 		if (raw.tool_calls?.length) {
 			for (const tc of raw.tool_calls) {
 				// Avoid duplicates
-				if (!toolCalls.some((t) => t.name === tc.tool_name)) {
+				if (!toolCalls.some((t) => t.id === tc.id || t.name === tc.tool_name)) {
 					toolCalls.push({
-						id: `tc_${index}_${tc.tool_name}`,
+						id: tc.id ?? `tc_${index}_${tc.tool_name}`,
 						name: tc.tool_name,
 						parameters: tc.parameters ?? {},
 					});
@@ -66,6 +69,9 @@ export function normalizeMessage(raw: RawMessage, index: number): ChatMessage {
 			timestamp,
 			toolResult: {
 				toolName: raw.metadata?.tool_name ?? 'unknown',
+				toolCallId: typeof raw.metadata?.tool_call_id === 'string' && raw.metadata.tool_call_id
+					? raw.metadata.tool_call_id
+					: undefined,
 				success: raw.metadata?.success ?? false,
 			},
 		};
@@ -88,7 +94,7 @@ export function normalizeMessage(raw: RawMessage, index: number): ChatMessage {
 	// Assistant messages may carry tool_calls at the top level
 	if (raw.role === 'assistant' && raw.tool_calls?.length) {
 		message.toolCalls = raw.tool_calls.map((tc, i) => ({
-			id: `tc_${index}_${i}_${tc.tool_name}`,
+			id: tc.id ?? `tc_${index}_${i}_${tc.tool_name}`,
 			name: tc.tool_name,
 			parameters: tc.parameters ?? {},
 		}));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -31,6 +31,7 @@ export interface RawMessage {
 		timestamp?: string;
 		type?: 'text' | 'multimodal' | 'tool_call' | 'tool_result';
 		tool_name?: string;
+		tool_call_id?: string;
 		parameters?: Record<string, unknown>;
 		success?: boolean;
 		error?: string;
@@ -42,6 +43,7 @@ export interface RawMessage {
 		media?: RawAttachment[];
 	};
 	tool_calls?: Array<{
+		id?: string;
 		tool_name: string;
 		parameters: Record<string, unknown>;
 	}>;

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -34,6 +34,8 @@ export interface ToolCall {
 export interface ToolResultMeta {
 	/** The tool that produced this result. */
 	toolName: string;
+	/** Tool call ID this result answers, when provided by the backend. */
+	toolCallId?: string;
 	/** Whether the tool call succeeded. */
 	success: boolean;
 }


### PR DESCRIPTION
## Summary
- Preserve backend tool call IDs in normalized chat messages.
- Pair tool calls/results by call ID before falling back to tool name.
- Prevent repeated tool names in a session from flushing older question cards above assistant replies.

## Testing
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed repeated-tool ordering behavior and drafted call-ID pairing changes for Chris to review/test.
