### PR TITLE
Add long-running chat run controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Backends that support long-running chat turns can opt into stop and queue UI wit
   onCancelRun={async ({ runId, sessionId }) => {
     await cancelRun({ runId, sessionId });
   }}
-  onQueueMessage={async ({ sessionId, content, files }) => {
-    await queueMessage({ sessionId, content, files });
+  onQueueMessage={async ({ sessionId, runId, content, files }) => {
+    return queueMessage({ sessionId, runId, content, files });
   }}
 />
 ```
@@ -114,7 +114,7 @@ Capability behavior:
 - Queue support: input and message suggestions stay usable while loading and submitted messages render optimistically with a queued state.
 - Cancel + queue support: both controls are enabled together.
 
-If a backend returns run IDs in response metadata, adapters can expose them generically through `getRunId`:
+The public TypeScript API uses camelCase (`runId`, `queuedMessageId`) while adapters can map whatever wire format their backend uses. If a backend returns run IDs in response metadata, adapters can expose them generically through `getRunId`:
 
 ```tsx
 <Chat
@@ -125,6 +125,8 @@ If a backend returns run IDs in response metadata, adapters can expose them gene
   onCancelRun={cancelRun}
 />
 ```
+
+`onQueueMessage` may return `{ queuedMessageId, position, runId, sessionId, status }` when the adapter has an acknowledgement payload. The UI does not require those fields, but the types preserve them for adapters that want to coordinate follow-up polling or session refreshes.
 
 ## Consumers
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,45 @@ Pass `messageSuggestions` to offer optional prompt starters on fresh conversatio
 />
 ```
 
+## Long-Running Turns
+
+Backends that support long-running chat turns can opt into stop and queue UI without changing the default behavior. When no capability is provided, the input is disabled while a response is loading, matching earlier releases.
+
+```tsx
+<Chat
+  basePath="/chat"
+  fetchFn={fetchChatJson}
+  initialSessionId="session-123"
+  runCapabilities={{ cancel: true, queue: true }}
+  activeRunId={activeRunId}
+  onCancelRun={async ({ runId, sessionId }) => {
+    await cancelRun({ runId, sessionId });
+  }}
+  onQueueMessage={async ({ sessionId, content, files }) => {
+    await queueMessage({ sessionId, content, files });
+  }}
+/>
+```
+
+Capability behavior:
+
+- No support: input and message suggestions stay disabled while loading.
+- Cancel support: a stop control appears while loading once both `activeRunId` and `sessionId` are available.
+- Queue support: input and message suggestions stay usable while loading and submitted messages render optimistically with a queued state.
+- Cancel + queue support: both controls are enabled together.
+
+If a backend returns run IDs in response metadata, adapters can expose them generically through `getRunId`:
+
+```tsx
+<Chat
+  basePath="/chat"
+  fetchFn={fetchChatJson}
+  runCapabilities={{ cancel: true }}
+  getRunId={(metadata) => typeof metadata.run_id === 'string' ? metadata.run_id : null}
+  onCancelRun={cancelRun}
+/>
+```
+
 ## Consumers
 
 - **extrachill-studio** — Studio Chat tab (agent_id=5)

--- a/css/chat.css
+++ b/css/chat.css
@@ -52,6 +52,8 @@
 	--ec-chat-send-bg: #2563eb;
 	--ec-chat-send-text: #ffffff;
 	--ec-chat-send-disabled-opacity: 0.4;
+	--ec-chat-cancel-bg: #ef4444;
+	--ec-chat-cancel-text: #ffffff;
 
 	/* Tool messages */
 	--ec-chat-tool-bg: #f9fafb;
@@ -112,6 +114,8 @@
 
 		--ec-chat-send-bg: #3b82f6;
 		--ec-chat-send-text: #ffffff;
+		--ec-chat-cancel-bg: #f87171;
+		--ec-chat-cancel-text: #111827;
 
 		--ec-chat-tool-bg: #1e293b;
 		--ec-chat-tool-border: #334155;
@@ -521,6 +525,25 @@
 	opacity: 1;
 }
 
+.ec-chat-message--queued .ec-chat-message__bubble,
+.ec-chat-message--failed .ec-chat-message__bubble {
+	opacity: 0.72;
+}
+
+.ec-chat-message__status {
+	font-size: 11px;
+	color: var(--ec-chat-text-muted);
+	margin-top: 2px;
+}
+
+.ec-chat-message--user .ec-chat-message__status {
+	align-self: flex-end;
+}
+
+.ec-chat-message--failed .ec-chat-message__status {
+	color: var(--ec-chat-tool-error);
+}
+
 /* ============================================
    Chat Input
    ============================================ */
@@ -557,7 +580,8 @@
 	color: var(--ec-chat-text-muted);
 }
 
-.ec-chat-input__send {
+.ec-chat-input__send,
+.ec-chat-input__cancel {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -572,16 +596,29 @@
 	transition: opacity 0.15s;
 }
 
-.ec-chat-input__send:disabled {
+.ec-chat-input__send {
+	background: var(--ec-chat-send-bg);
+	color: var(--ec-chat-send-text);
+}
+
+.ec-chat-input__cancel {
+	background: var(--ec-chat-cancel-bg);
+	color: var(--ec-chat-cancel-text);
+}
+
+.ec-chat-input__send:disabled,
+.ec-chat-input__cancel:disabled {
 	opacity: var(--ec-chat-send-disabled-opacity);
 	cursor: not-allowed;
 }
 
-.ec-chat-input__send:not(:disabled):hover {
+.ec-chat-input__send:not(:disabled):hover,
+.ec-chat-input__cancel:not(:disabled):hover {
 	opacity: 0.9;
 }
 
-.ec-chat-input__send-icon {
+.ec-chat-input__send-icon,
+.ec-chat-input__stop-icon {
 	display: block;
 }
 

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -139,6 +139,18 @@ export interface ChatProps {
 	 * ```
 	 */
 	mediaUploadFn?: MediaUploadFn;
+	/** Optional long-running turn capabilities supplied by the backend adapter. */
+	runCapabilities?: UseChatOptions['runCapabilities'];
+	/** Active backend run ID, when the adapter already knows it. */
+	activeRunId?: UseChatOptions['activeRunId'];
+	/** Extract a backend run ID from response metadata. */
+	getRunId?: UseChatOptions['getRunId'];
+	/** Cancel the active backend run. Called only when cancel support is enabled. */
+	onCancelRun?: UseChatOptions['onCancelRun'];
+	/** Queue a follow-up message. Called only when queue support is enabled. */
+	onQueueMessage?: UseChatOptions['onQueueMessage'];
+	/** Accessible label for the stop/cancel control. */
+	cancelLabel?: string;
 	/**
 	 * Arbitrary metadata forwarded to the backend with each message.
 	 * Use for client-side context injection (e.g. `{ client_context: { tab: 'compose', postId: 123 } }`).
@@ -220,6 +232,12 @@ export function Chat({
 	allowAttachments,
 	acceptFileTypes,
 	mediaUploadFn,
+	runCapabilities,
+	activeRunId,
+	getRunId,
+	onCancelRun,
+	onQueueMessage,
+	cancelLabel,
 	metadata,
 	showCopyTranscript = false,
 	copyTranscriptLabel,
@@ -245,6 +263,11 @@ export function Chat({
 		sessionContext,
 		metadata,
 		mediaUploadFn,
+		runCapabilities,
+		activeRunId,
+		getRunId,
+		onCancelRun,
+		onQueueMessage,
 	});
 
 	// Fire onUnreadChange whenever totalUnreadCount changes.
@@ -288,7 +311,7 @@ export function Chat({
 				suggestions={resolvedMessageSuggestions}
 				onSelect={(suggestion) => chat.sendMessage(suggestion.message ?? suggestion.label)}
 				label={messageSuggestionsLabel}
-				disabled={chat.isLoading}
+				disabled={chat.isLoading && !chat.canQueueMessage}
 			/>
 		</div>
 	) : emptyState;
@@ -343,7 +366,11 @@ export function Chat({
 
 					<ChatInput
 						onSend={chat.sendMessage}
-						disabled={chat.isLoading}
+						onCancel={chat.cancelRun}
+						disabled={chat.isLoading && !chat.canQueueMessage}
+						showCancel={chat.canCancelRun}
+						cancelLoading={chat.isCancelling}
+						cancelLabel={cancelLabel}
 						placeholder={placeholder}
 						allowAttachments={resolvedAllowAttachments}
 						accept={acceptFileTypes}

--- a/src/api.ts
+++ b/src/api.ts
@@ -52,6 +52,8 @@ export interface ChatApiConfig {
 
 export interface SendResult {
 	sessionId: string;
+	/** Opaque ID for the accepted chat run, when supplied by the backend. */
+	runId: string | null;
 	messages: ChatMessage[];
 	metadata: Record<string, unknown>;
 	completed: boolean;
@@ -60,6 +62,8 @@ export interface SendResult {
 }
 
 export interface ContinueResult {
+	/** Opaque ID for the active chat run, when supplied by the backend. */
+	runId: string | null;
 	messages: ChatMessage[];
 	metadata: Record<string, unknown>;
 	completed: boolean;
@@ -140,6 +144,7 @@ export async function sendMessage(
 
 	return {
 		sessionId: raw.data.session_id,
+		runId: typeof raw.data.run_id === 'string' ? raw.data.run_id : null,
 		messages: normalizeConversation(raw.data.conversation),
 		metadata: raw.data.metadata ?? {},
 		completed: raw.data.completed,
@@ -166,6 +171,7 @@ export async function continueResponse(
 	}
 
 	return {
+		runId: typeof raw.data.run_id === 'string' ? raw.data.run_id : null,
 		messages: raw.data.new_messages.map(normalizeMessage),
 		metadata: raw.data.metadata ?? {},
 		completed: raw.data.completed,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -3,8 +3,16 @@ import { useState, useRef, useCallback, type KeyboardEvent, type FormEvent, type
 export interface ChatInputProps {
 	/** Called when the user submits a message (with optional file attachments). */
 	onSend: (content: string, files?: File[]) => void;
+	/** Called when the user requests cancellation of the active run. */
+	onCancel?: () => void;
 	/** Whether input is disabled (e.g. while waiting for response). */
 	disabled?: boolean;
+	/** Whether to show the stop/cancel control. */
+	showCancel?: boolean;
+	/** Whether cancellation is currently in progress. */
+	cancelLoading?: boolean;
+	/** Accessible label for the stop/cancel control. Defaults to 'Stop response'. */
+	cancelLabel?: string;
 	/** Placeholder text. Defaults to 'Type a message...'. */
 	placeholder?: string;
 	/** Maximum number of rows the textarea auto-grows to. Defaults to 6. */
@@ -29,7 +37,11 @@ export interface ChatInputProps {
  */
 export function ChatInput({
 	onSend,
+	onCancel,
 	disabled = false,
+	showCancel = false,
+	cancelLoading = false,
+	cancelLabel = 'Stop response',
 	placeholder = 'Type a message...',
 	maxRows = 6,
 	accept = 'image/*,video/*',
@@ -181,6 +193,18 @@ export function ChatInput({
 					rows={1}
 					aria-label={placeholder}
 				/>
+				{showCancel && (
+					<button
+						className={`${baseClass}__cancel`}
+						type="button"
+						onClick={onCancel}
+						disabled={cancelLoading}
+						aria-label={cancelLabel}
+						title={cancelLabel}
+					>
+						<StopIcon />
+					</button>
+				)}
 				<button
 					className={`${baseClass}__send`}
 					type="submit"
@@ -236,6 +260,14 @@ function SendIcon() {
 		>
 			<line x1="22" y1="2" x2="11" y2="13" />
 			<polygon points="22 2 15 22 11 13 2 9 22 2" />
+		</svg>
+	);
+}
+
+function StopIcon() {
+	return (
+		<svg className="ec-chat-input__stop-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+			<rect x="7" y="7" width="10" height="10" rx="1" fill="currentColor" stroke="none" />
 		</svg>
 	);
 }

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -33,7 +33,8 @@ export function ChatMessage({
 	const isUser = message.role === 'user';
 	const baseClass = 'ec-chat-message';
 	const roleClass = isUser ? `${baseClass}--user` : `${baseClass}--assistant`;
-	const classes = [baseClass, roleClass, className].filter(Boolean).join(' ');
+	const statusClass = message.deliveryStatus ? `${baseClass}--${message.deliveryStatus}` : '';
+	const classes = [baseClass, roleClass, statusClass, className].filter(Boolean).join(' ');
 
 	const hasText = message.content.trim().length > 0;
 	const hasAttachments = message.attachments && message.attachments.length > 0;
@@ -58,6 +59,11 @@ export function ChatMessage({
 				>
 					{formatTime(message.timestamp)}
 				</time>
+			)}
+			{message.deliveryStatus && (
+				<span className={`${baseClass}__status`}>
+					{message.deliveryStatus === 'queued' ? 'Queued' : 'Failed'}
+				</span>
 			)}
 		</div>
 	);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,11 @@
-export { useChat, type UseChatOptions, type UseChatReturn } from './useChat.ts';
+export {
+	useChat,
+	type CancelRunInput,
+	type ChatRunCapabilities,
+	type QueueMessageInput,
+	type UseChatOptions,
+	type UseChatReturn,
+} from './useChat.ts';
 export {
 	useLoadingMessages,
 	DEFAULT_LOADING_MESSAGES,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,8 +1,11 @@
 export {
 	useChat,
+	type ChatRun,
 	type CancelRunInput,
 	type ChatRunCapabilities,
+	type ChatRunStatus,
 	type QueueMessageInput,
+	type QueueMessageResult,
 	type UseChatOptions,
 	type UseChatReturn,
 } from './useChat.ts';

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -13,6 +13,24 @@ import {
 	markSessionRead as apiMarkSessionRead,
 } from '../api.ts';
 
+export interface ChatRunCapabilities {
+	/** Whether the current backend adapter can cancel an active run. */
+	cancel?: boolean;
+	/** Whether the current backend adapter can queue follow-up messages. */
+	queue?: boolean;
+}
+
+export interface CancelRunInput {
+	runId: string;
+	sessionId: string;
+}
+
+export interface QueueMessageInput {
+	sessionId: string;
+	content: string;
+	files?: File[];
+}
+
 /**
  * Configuration for the useChat hook.
  */
@@ -76,6 +94,16 @@ export interface UseChatOptions {
 	 * in the composed Chat component) because files cannot be processed.
 	 */
 	mediaUploadFn?: MediaUploadFn;
+	/** Optional long-running turn capabilities supplied by the backend adapter. */
+	runCapabilities?: ChatRunCapabilities;
+	/** Active backend run ID, when the adapter already knows it. */
+	activeRunId?: string | null;
+	/** Extract a backend run ID from response metadata. */
+	getRunId?: (metadata: Record<string, unknown>) => string | null | undefined;
+	/** Cancel the active backend run. Called only when `runCapabilities.cancel` is enabled. */
+	onCancelRun?: (input: CancelRunInput) => Promise<void> | void;
+	/** Queue a follow-up message. Called only when `runCapabilities.queue` is enabled. */
+	onQueueMessage?: (input: QueueMessageInput) => Promise<void> | void;
 	/**
 	 * Optional context filter for session listing.
 	 * Only sessions created in the matching context are shown.
@@ -91,6 +119,8 @@ export interface UseChatReturn {
 	messages: ChatMessage[];
 	/** Whether a message is being sent/processed. */
 	isLoading: boolean;
+	/** Whether cancellation is currently being requested. */
+	isCancelling: boolean;
 	/** Current continuation turn count (0 when not processing). */
 	turnCount: number;
 	/** Current availability state. */
@@ -104,6 +134,14 @@ export interface UseChatReturn {
 	 * Null when idle.
 	 */
 	processingSessionId: string | null;
+	/** Active backend run ID, when supplied by the adapter or response metadata. */
+	activeRunId: string | null;
+	/** Configured long-running turn capabilities. */
+	runCapabilities: ChatRunCapabilities;
+	/** Whether the active run can be cancelled right now. */
+	canCancelRun: boolean;
+	/** Whether follow-up messages can be queued right now. */
+	canQueueMessage: boolean;
 	/** List of sessions. */
 	sessions: ChatSession[];
 	/** Whether sessions are loading. */
@@ -114,6 +152,8 @@ export interface UseChatReturn {
 	totalUnreadCount: number;
 	/** Send a user message (with optional file attachments). */
 	sendMessage: (content: string, files?: File[]) => void;
+	/** Cancel the active run when the adapter supports it. */
+	cancelRun: () => Promise<void>;
 	/** Switch to a different session. */
 	switchSession: (sessionId: string) => void;
 	/** Create a new session. */
@@ -189,14 +229,21 @@ export function useChat({
 	onResponseMetadata,
 	metadata,
 	mediaUploadFn,
+	runCapabilities,
+	activeRunId,
+	getRunId,
+	onCancelRun,
+	onQueueMessage,
 	sessionContext,
 }: UseChatOptions): UseChatReturn {
 	const [messages, setMessages] = useState<ChatMessage[]>(initialMessages ?? []);
 	const [isLoading, setIsLoading] = useState(false);
+	const [isCancelling, setIsCancelling] = useState(false);
 	const [turnCount, setTurnCount] = useState(0);
 	const [availability, setAvailability] = useState<ChatAvailability>({ status: 'ready' });
 	const [sessionId, setSessionId] = useState<string | null>(initialSessionId ?? null);
 	const [processingSessionId, setProcessingSessionId] = useState<string | null>(null);
+	const [metadataRunId, setMetadataRunId] = useState<string | null>(null);
 	const [sessions, setSessions] = useState<ChatSession[]>([]);
 	const [sessionsLoading, setSessionsLoading] = useState(false);
 
@@ -204,6 +251,21 @@ export function useChat({
 	const totalUnreadCount = sessions.reduce((sum, s) => sum + (s.unreadCount ?? 0), 0);
 	const activeSession = sessionId ? sessions.find((s) => s.id === sessionId) : undefined;
 	const unreadCount = activeSession?.unreadCount ?? 0;
+	const resolvedRunCapabilities = runCapabilities ?? {};
+	const resolvedActiveRunId = activeRunId ?? metadataRunId;
+	const canCancelRun = !!(
+		isLoading &&
+		resolvedRunCapabilities.cancel &&
+		onCancelRun &&
+		resolvedActiveRunId &&
+		sessionId
+	);
+	const canQueueMessage = !!(
+		isLoading &&
+		resolvedRunCapabilities.queue &&
+		onQueueMessage &&
+		sessionId
+	);
 
 	// Build API config from props
 	const configRef = useRef<ChatApiConfig>({ basePath, fetchFn, agentId });
@@ -221,11 +283,31 @@ export function useChat({
 	metadataRef.current = metadata;
 	const mediaUploadFnRef = useRef(mediaUploadFn);
 	mediaUploadFnRef.current = mediaUploadFn;
+	const runCapabilitiesRef = useRef(resolvedRunCapabilities);
+	runCapabilitiesRef.current = resolvedRunCapabilities;
+	const activeRunIdRef = useRef(resolvedActiveRunId);
+	activeRunIdRef.current = resolvedActiveRunId;
+	const getRunIdRef = useRef(getRunId);
+	getRunIdRef.current = getRunId;
+	const onCancelRunRef = useRef(onCancelRun);
+	onCancelRunRef.current = onCancelRun;
+	const onQueueMessageRef = useRef(onQueueMessage);
+	onQueueMessageRef.current = onQueueMessage;
 	const sessionContextRef = useRef(sessionContext);
 	sessionContextRef.current = sessionContext;
 	// Guard against concurrent session creation.
 	const isCreatingRef = useRef(false);
 	const hasInitialMessagesRef = useRef((initialMessages?.length ?? 0) > 0);
+	const activeRequestIdRef = useRef(0);
+	const cancelledRequestIdRef = useRef<number | null>(null);
+
+	const applyResponseMetadata = useCallback((responseMetadata: Record<string, unknown>) => {
+		onResponseMetadataRef.current?.(responseMetadata);
+		const runId = getRunIdRef.current?.(responseMetadata);
+		if (runId !== undefined) {
+			setMetadataRunId(runId);
+		}
+	}, []);
 
 	// Load sessions on mount
 	useEffect(() => {
@@ -278,7 +360,45 @@ export function useChat({
 	}, []);
 
 	const sendMessage = useCallback(async (content: string, files?: File[]) => {
-		if (isLoading || isCreatingRef.current) return;
+		if (isLoading) {
+			const currentSessionId = sessionIdRef.current;
+			const queueMessage = onQueueMessageRef.current;
+			if (!runCapabilitiesRef.current.queue || !queueMessage || !currentSessionId) return;
+
+			const queuedMessage: ChatMessage = {
+				id: generateMessageId(),
+				role: 'user',
+				content,
+				timestamp: new Date().toISOString(),
+				deliveryStatus: 'queued',
+			};
+
+			setMessages((prev) => [...prev, queuedMessage]);
+			onMessage?.(queuedMessage);
+
+			try {
+				await queueMessage({
+					sessionId: currentSessionId,
+					content,
+					files,
+				});
+			} catch (err) {
+				const error = toError(err);
+				onError?.(error);
+				setMessages((prev) => prev.map((message) => (
+					message.id === queuedMessage.id
+						? { ...message, deliveryStatus: 'failed' }
+						: message
+				)));
+			}
+			return;
+		}
+
+		if (isCreatingRef.current) return;
+
+		const requestId = activeRequestIdRef.current + 1;
+		activeRequestIdRef.current = requestId;
+		cancelledRequestIdRef.current = null;
 
 		// Build optimistic attachment previews from local files.
 		let optimisticAttachments: MediaAttachment[] | undefined;
@@ -355,6 +475,8 @@ export function useChat({
 				metadataRef.current,
 			);
 
+			if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) return;
+
 			isCreatingRef.current = false;
 
 			// Update session ID (may be newly created)
@@ -364,7 +486,7 @@ export function useChat({
 
 			// Replace all messages with the full normalized conversation
 			setMessages(result.messages);
-			onResponseMetadataRef.current?.(result.metadata);
+			applyResponseMetadata(result.metadata);
 
 			// Fire tool call callback for the initial response.
 			fireToolCalls(result.messages);
@@ -375,6 +497,7 @@ export function useChat({
 				let turns = 0;
 
 				while (!completed && turns < maxContinueTurns) {
+					if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) break;
 					turns++;
 					setTurnCount(turns);
 
@@ -383,8 +506,10 @@ export function useChat({
 						result.sessionId,
 					);
 
+					if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) break;
+
 					setMessages((prev) => [...prev, ...continuation.messages]);
-					onResponseMetadataRef.current?.(continuation.metadata);
+					applyResponseMetadata(continuation.metadata);
 					for (const msg of continuation.messages) {
 						onMessage?.(msg);
 					}
@@ -420,11 +545,39 @@ export function useChat({
 			};
 			setMessages((prev) => [...prev, errorMessage]);
 		} finally {
+			if (activeRequestIdRef.current === requestId) {
+				setIsLoading(false);
+				setTurnCount(0);
+				setProcessingSessionId(null);
+				setMetadataRunId(null);
+			}
+		}
+	}, [isLoading, maxContinueTurns, onMessage, onError, fireToolCalls, applyResponseMetadata]);
+
+	const cancelRun = useCallback(async () => {
+		const cancelRunCallback = onCancelRunRef.current;
+		const runId = activeRunIdRef.current;
+		const currentSessionId = sessionIdRef.current;
+		if (!cancelRunCallback || !runCapabilitiesRef.current.cancel || !runId || !currentSessionId) return;
+
+		setIsCancelling(true);
+		const cancelledRequestId = activeRequestIdRef.current;
+		cancelledRequestIdRef.current = cancelledRequestId;
+
+		try {
+			await cancelRunCallback({ runId, sessionId: currentSessionId });
+			activeRequestIdRef.current = cancelledRequestId + 1;
 			setIsLoading(false);
 			setTurnCount(0);
 			setProcessingSessionId(null);
+			setMetadataRunId(null);
+		} catch (err) {
+			cancelledRequestIdRef.current = null;
+			onError?.(toError(err));
+		} finally {
+			setIsCancelling(false);
 		}
-	}, [isLoading, maxContinueTurns, onMessage, onError, fireToolCalls]);
+	}, [onError]);
 
 	const switchSession = useCallback(async (newSessionId: string) => {
 		setSessionId(newSessionId);
@@ -504,15 +657,21 @@ export function useChat({
 	return {
 		messages,
 		isLoading,
+		isCancelling,
 		turnCount,
 		availability,
 		sessionId,
 		processingSessionId,
+		activeRunId: resolvedActiveRunId,
+		runCapabilities: resolvedRunCapabilities,
+		canCancelRun,
+		canQueueMessage,
 		sessions,
 		sessionsLoading,
 		unreadCount,
 		totalUnreadCount,
 		sendMessage,
+		cancelRun,
 		switchSession,
 		newSession,
 		deleteSession: deleteSessionHandler,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -20,6 +20,17 @@ export interface ChatRunCapabilities {
 	queue?: boolean;
 }
 
+export type ChatRunStatus = 'queued' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed';
+
+export interface ChatRun {
+	runId: string;
+	sessionId: string;
+	status?: ChatRunStatus;
+	startedAt?: string;
+	updatedAt?: string;
+	metadata?: Record<string, unknown>;
+}
+
 export interface CancelRunInput {
 	runId: string;
 	sessionId: string;
@@ -27,8 +38,17 @@ export interface CancelRunInput {
 
 export interface QueueMessageInput {
 	sessionId: string;
+	/** Active run this message should follow, when known. */
+	runId?: string;
 	content: string;
 	files?: File[];
+}
+
+export interface QueueMessageResult extends Partial<ChatRun> {
+	/** Opaque ID assigned to the queued user message. */
+	queuedMessageId?: string;
+	/** Zero-based or one-based queue position, as reported by the adapter. */
+	position?: number;
 }
 
 /**
@@ -103,7 +123,7 @@ export interface UseChatOptions {
 	/** Cancel the active backend run. Called only when `runCapabilities.cancel` is enabled. */
 	onCancelRun?: (input: CancelRunInput) => Promise<void> | void;
 	/** Queue a follow-up message. Called only when `runCapabilities.queue` is enabled. */
-	onQueueMessage?: (input: QueueMessageInput) => Promise<void> | void;
+	onQueueMessage?: (input: QueueMessageInput) => Promise<QueueMessageResult | void> | QueueMessageResult | void;
 	/**
 	 * Optional context filter for session listing.
 	 * Only sessions created in the matching context are shown.
@@ -189,6 +209,11 @@ function toError(err: unknown): Error {
 		try { return new Error(JSON.stringify(err)); } catch { /* fall through */ }
 	}
 	return new Error('An unknown error occurred');
+}
+
+function extractRunId(metadata: Record<string, unknown>): string | null {
+	const runId = metadata.runId ?? metadata.run_id;
+	return typeof runId === 'string' && runId.trim() ? runId : null;
 }
 
 /**
@@ -303,8 +328,14 @@ export function useChat({
 
 	const applyResponseMetadata = useCallback((responseMetadata: Record<string, unknown>) => {
 		onResponseMetadataRef.current?.(responseMetadata);
-		const runId = getRunIdRef.current?.(responseMetadata);
-		if (runId !== undefined) {
+		const mappedRunId = getRunIdRef.current?.(responseMetadata);
+		if (mappedRunId !== undefined) {
+			setMetadataRunId(mappedRunId);
+			return;
+		}
+
+		const runId = extractRunId(responseMetadata);
+		if (runId) {
 			setMetadataRunId(runId);
 		}
 	}, []);
@@ -365,6 +396,7 @@ export function useChat({
 			const queueMessage = onQueueMessageRef.current;
 			if (!runCapabilitiesRef.current.queue || !queueMessage || !currentSessionId) return;
 
+			const activeRunId = activeRunIdRef.current ?? undefined;
 			const queuedMessage: ChatMessage = {
 				id: generateMessageId(),
 				role: 'user',
@@ -377,11 +409,15 @@ export function useChat({
 			onMessage?.(queuedMessage);
 
 			try {
-				await queueMessage({
+				const queued = await queueMessage({
 					sessionId: currentSessionId,
+					runId: activeRunId,
 					content,
 					files,
 				});
+				if (queued?.runId) {
+					setMetadataRunId(queued.runId);
+				}
 			} catch (err) {
 				const error = toError(err);
 				onError?.(error);
@@ -486,6 +522,7 @@ export function useChat({
 
 			// Replace all messages with the full normalized conversation
 			setMessages(result.messages);
+			setMetadataRunId(result.runId);
 			applyResponseMetadata(result.metadata);
 
 			// Fire tool call callback for the initial response.
@@ -509,6 +546,9 @@ export function useChat({
 					if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) break;
 
 					setMessages((prev) => [...prev, ...continuation.messages]);
+					if (continuation.runId) {
+						setMetadataRunId(continuation.runId);
+					}
 					applyResponseMetadata(continuation.metadata);
 					for (const msg of continuation.messages) {
 						onMessage?.(msg);

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,9 @@ export {
 // Hooks
 export {
 	useChat,
+	type CancelRunInput,
+	type ChatRunCapabilities,
+	type QueueMessageInput,
 	type UseChatOptions,
 	type UseChatReturn,
 } from './hooks/useChat.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,9 +135,12 @@ export {
 // Hooks
 export {
 	useChat,
+	type ChatRun,
 	type CancelRunInput,
 	type ChatRunCapabilities,
+	type ChatRunStatus,
 	type QueueMessageInput,
+	type QueueMessageResult,
 	type UseChatOptions,
 	type UseChatReturn,
 } from './hooks/useChat.ts';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -69,6 +69,8 @@ export interface SendResponse {
 	success: boolean;
 	data: {
 		session_id: string;
+		/** Opaque ID for the accepted chat run. */
+		run_id?: string;
 		response: string;
 		tool_calls: Array<{
 			tool_name: string;
@@ -95,6 +97,8 @@ export interface ContinueResponse {
 	success: boolean;
 	data: {
 		session_id: string;
+		/** Opaque ID for the active chat run. */
+		run_id?: string;
 		new_messages: RawMessage[];
 		final_content: string;
 		tool_calls: Array<{

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -80,6 +80,8 @@ export interface ChatMessage {
 	toolResult?: ToolResultMeta;
 	/** Media attachments (images, videos, files) on this message. */
 	attachments?: MediaAttachment[];
+	/** Client-side delivery state for optimistic messages. */
+	deliveryStatus?: 'queued' | 'failed';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds backend-neutral `runCapabilities` primitives for optional active-run cancellation and queued follow-up messages.
- Exposes `activeRunId`, `getRunId`, `cancelRun`, `canCancelRun`, and `canQueueMessage` through `useChat` so adapters can wire their own backend contract.
- Updates `ChatInput`/message rendering to show a stop control and optimistic queued/failed message states only when the capability is supplied.

## Notes
- Preserves existing disabled-input behavior by default when no queue capability is configured.
- Coordinates with the contract shape discussed in Automattic/agents-api#236 without hardcoding Agents API, WordPress, Studio Web, or frontend-agent-chat details.
- Closes #38.

## Verification
- `npm run build`
- `homeboy test --path /Users/chubes/Developer/chat@feat-long-running-turn-primitives --extension nodejs` (0 tests detected by repo)
- `homeboy lint --path /Users/chubes/Developer/chat@feat-long-running-turn-primitives --extension nodejs` (no lint surface detected)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the backend-neutral run-control API, UI state wiring, documentation, and verification. Chris remains responsible for review and merge.