### PR TITLE
fix: keep loading messages during tool turns

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -288,6 +288,44 @@
 	font-weight: 600;
 }
 
+.ec-chat-question__submitted-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.ec-chat-question__submitted-answer {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--ec-chat-text-muted);
+}
+
+.ec-chat-question__submitted-check {
+	color: var(--ec-chat-success, #16a34a);
+	font-weight: 700;
+}
+
+.ec-chat-question__toggle {
+	appearance: none;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 999px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text-muted);
+	cursor: pointer;
+	font: inherit;
+	font-size: 12px;
+	line-height: 1;
+	padding: 6px 10px;
+	white-space: nowrap;
+}
+
+.ec-chat-question__toggle:hover {
+	border-color: var(--ec-chat-input-focus-border);
+	color: var(--ec-chat-text);
+}
+
 .ec-chat-question__choices {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -310,6 +348,15 @@
 .ec-chat-question__choice:hover:not(:disabled) {
 	background: var(--ec-chat-session-hover-bg);
 	border-color: var(--ec-chat-input-focus-border);
+}
+
+.ec-chat-question__choice--readonly {
+	cursor: default;
+}
+
+.ec-chat-question__choice--selected {
+	border-color: var(--ec-chat-input-focus-border);
+	background: var(--ec-chat-session-hover-bg);
 }
 
 .ec-chat-question__choice:disabled,

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -319,13 +319,13 @@ export function Chat({
 		<TypingIndicator
 			visible={chat.isLoading}
 			label={
-				chat.turnCount > 0
+				hasLoadingMessages
+					? cycling.message
+					: chat.turnCount > 0
 					? (processingLabel
 						? processingLabel(chat.turnCount)
 						: `Processing turn ${chat.turnCount}...`)
-					: hasLoadingMessages
-						? cycling.message
-						: undefined
+					: undefined
 			}
 		/>
 	), [chat.isLoading, chat.turnCount, processingLabel, hasLoadingMessages, cycling.message]);

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -24,7 +24,7 @@ export interface QuestionCardProps {
 	onSubmitAnswer: (answer: string) => void;
 	/** Whether controls are disabled. */
 	disabled?: boolean;
-	/** Hide the card after the user submits an answer. Defaults to true. */
+	/** Collapse choices after the user submits an answer. Defaults to true. */
 	autoHideOnSubmit?: boolean;
 	/** Additional CSS class name. */
 	className?: string;
@@ -46,16 +46,20 @@ export function QuestionCard({
 	className,
 }: QuestionCardProps) {
 	const [freeformAnswer, setFreeformAnswer] = useState('');
-	const [submitted, setSubmitted] = useState(false);
+	const [submittedAnswer, setSubmittedAnswer] = useState<string | null>(null);
+	const [showChoices, setShowChoices] = useState(false);
 	const baseClass = 'ec-chat-question';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const submitted = submittedAnswer !== null;
 	const controlsDisabled = disabled || submitted;
 
 	function submitAnswer(answer: string) {
-		if (!answer.trim() || controlsDisabled) return;
-		onSubmitAnswer(answer);
+		const nextAnswer = answer.trim();
+		if (!nextAnswer || controlsDisabled) return;
+		onSubmitAnswer(nextAnswer);
 		if (autoHideOnSubmit) {
-			setSubmitted(true);
+			setSubmittedAnswer(nextAnswer);
+			setShowChoices(false);
 		}
 	}
 
@@ -68,7 +72,47 @@ export function QuestionCard({
 	}
 
 	if (submitted && autoHideOnSubmit) {
-		return null;
+		return (
+			<div className={`${classes} ${baseClass}--submitted`}>
+				<div className={`${baseClass}__submitted-header`}>
+					<div className={`${baseClass}__prompt`}>{question}</div>
+					{choices.length > 0 && (
+						<button
+							className={`${baseClass}__toggle`}
+							type="button"
+							onClick={() => setShowChoices((expanded) => !expanded)}
+							aria-expanded={showChoices}
+						>
+							{showChoices ? 'Hide choices' : 'Show choices'}
+						</button>
+					)}
+				</div>
+				<div className={`${baseClass}__submitted-answer`}>
+					<span className={`${baseClass}__submitted-check`} aria-hidden="true">✓</span>
+					<span>{submittedAnswer}</span>
+				</div>
+				{showChoices && choices.length > 0 && (
+					<div className={`${baseClass}__choices ${baseClass}__choices--readonly`} role="list" aria-label={question}>
+						{choices.map((choice, index) => {
+							const value = choice.message ?? choice.label;
+							const selected = value === submittedAnswer;
+							return (
+								<div
+									key={`${choice.label}-${index}`}
+									className={`${baseClass}__choice ${baseClass}__choice--readonly${selected ? ` ${baseClass}__choice--selected` : ''}`}
+									role="listitem"
+								>
+									<span className={`${baseClass}__choice-label`}>{choice.label}</span>
+									{choice.description && (
+										<span className={`${baseClass}__choice-description`}>{choice.description}</span>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		);
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- Keep configured loading messages visible while tool turns are still running.
- Collapse answered question choices so completed question cards do not keep presenting stale choices.

## Verification
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Dependency update workflow and verification; branch code pre-existed this frontend-agent-chat update.