### PR TITLE
Add citation rendering primitives

### DIFF
--- a/src/citations.ts
+++ b/src/citations.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import type { ChatCitation, ChatMessage } from './types/index.ts';
+
+/**
+ * Return citations attached to a message with invalid entries removed.
+ */
+export function getMessageCitations(message: ChatMessage | null | undefined): ChatCitation[] {
+	return (message?.citations ?? []).filter(isRenderableCitation);
+}
+
+/**
+ * React helper for components that need stable message citation lists.
+ */
+export function useMessageCitations(message: ChatMessage | null | undefined): ChatCitation[] {
+	return useMemo(() => getMessageCitations(message), [message]);
+}
+
+function isRenderableCitation(citation: ChatCitation): boolean {
+	return Boolean(
+		citation.url
+		|| citation.snippet
+		|| citation.source?.url
+		|| citation.source?.title
+		|| citation.source?.label
+		|| citation.source?.id
+	);
+}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,6 +1,8 @@
 import { type ReactNode, lazy, Suspense } from 'react';
-import type { ChatMessage as ChatMessageType, ContentFormat, MediaAttachment } from '../types/index.ts';
+import type { ChatCitation, ChatMessage as ChatMessageType, ContentFormat, MediaAttachment } from '../types/index.ts';
 import { markdownToHtml } from '../markdown.ts';
+import { getMessageCitations } from '../citations.ts';
+import { CitationsList } from './CitationsList.tsx';
 
 const ReactMarkdown = lazy(() => import('react-markdown'));
 
@@ -15,6 +17,8 @@ export interface ChatMessageProps {
 	renderContent?: (content: string, role: ChatMessageType['role']) => ReactNode;
 	/** Additional CSS class name on the outer wrapper. */
 	className?: string;
+	/** Custom citation renderer. Set to null to hide default citation rendering. */
+	renderCitations?: ((citations: ChatCitation[], message: ChatMessageType) => ReactNode) | null;
 }
 
 /**
@@ -29,6 +33,7 @@ export function ChatMessage({
 	contentFormat = 'markdown',
 	renderContent,
 	className,
+	renderCitations,
 }: ChatMessageProps) {
 	const isUser = message.role === 'user';
 	const baseClass = 'ec-chat-message';
@@ -38,6 +43,8 @@ export function ChatMessage({
 
 	const hasText = message.content.trim().length > 0;
 	const hasAttachments = message.attachments && message.attachments.length > 0;
+	const citations = getMessageCitations(message);
+	const shouldRenderCitations = message.role === 'assistant' && citations.length > 0 && renderCitations !== null;
 
 	return (
 		<div className={classes} data-message-id={message.id}>
@@ -49,6 +56,11 @@ export function ChatMessage({
 				)}
 				{hasAttachments && (
 					<MessageAttachments attachments={message.attachments!} />
+				)}
+				{shouldRenderCitations && (
+					renderCitations
+						? renderCitations(citations, message)
+						: <CitationsList citations={citations} />
 				)}
 			</div>
 			{message.timestamp && (

--- a/src/components/CitationsList.tsx
+++ b/src/components/CitationsList.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import type { ChatCitation } from '../types/index.ts';
+
+export interface CitationBadgeProps {
+	/** Citation to render. */
+	citation: ChatCitation;
+	/** One-based fallback index used when citation.index is omitted. */
+	index?: number;
+	/** Additional CSS class name on the badge. */
+	className?: string;
+}
+
+export interface CitationsListProps {
+	/** Citations to render. */
+	citations: ChatCitation[];
+	/** Accessible label for the citation list. */
+	label?: string;
+	/** Optional custom citation renderer. */
+	renderCitation?: (citation: ChatCitation, index: number) => ReactNode;
+	/** Additional CSS class name on the outer wrapper. */
+	className?: string;
+}
+
+export function CitationsList({
+	citations,
+	label = 'Sources',
+	renderCitation,
+	className,
+}: CitationsListProps) {
+	if (citations.length === 0) {
+		return null;
+	}
+
+	const baseClass = 'ec-chat-citations';
+	const classes = [baseClass, className].filter(Boolean).join(' ');
+
+	return (
+		<section className={classes} aria-label={label}>
+			<div className={`${baseClass}__label`}>{label}</div>
+			<ol className={`${baseClass}__list`}>
+				{citations.map((citation, index) => (
+					<li className={`${baseClass}__item`} key={citation.id ?? citation.source?.id ?? index}>
+						{renderCitation
+							? renderCitation(citation, index + 1)
+							: <CitationBadge citation={citation} index={index + 1} />}
+					</li>
+				))}
+			</ol>
+		</section>
+	);
+}
+
+export function CitationBadge({ citation, index, className }: CitationBadgeProps) {
+	const baseClass = 'ec-chat-citation';
+	const classes = [baseClass, className].filter(Boolean).join(' ');
+	const href = citation.url ?? citation.source?.url;
+	const label = citation.source?.title ?? citation.source?.label ?? citation.source?.id ?? href ?? 'Source';
+	const number = citation.index ?? index;
+	const content = (
+		<>
+			{number != null && <span className={`${baseClass}__index`}>{number}</span>}
+			<span className={`${baseClass}__label`}>{label}</span>
+			{citation.snippet && <span className={`${baseClass}__snippet`}>{citation.snippet}</span>}
+		</>
+	);
+
+	if (href) {
+		return (
+			<a className={classes} href={href} target="_blank" rel="noopener noreferrer">
+				{content}
+			</a>
+		);
+	}
+
+	return <span className={classes}>{content}</span>;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export { SessionSwitcher, type SessionSwitcherProps } from './SessionSwitcher.ts
 export { MessageSuggestions, type ChatMessageSuggestion, type MessageSuggestionsProps } from './MessageSuggestions.tsx';
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.tsx';
 export { AvailabilityGate, type AvailabilityGateProps } from './AvailabilityGate.tsx';
+export { CitationsList, CitationBadge, type CitationsListProps, type CitationBadgeProps } from './CitationsList.tsx';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,3 +15,4 @@ export {
 	type LoadingMessagesConfig,
 	type UseLoadingMessagesReturn,
 } from './useLoadingMessages.ts';
+export { useMessageCitations } from '../citations.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,17 @@ export type {
 	ToolCall,
 	ToolResultMeta,
 	MediaAttachment,
+	ChatCitation,
+	ChatSource,
 	ChatMessage,
 	ContentFormat,
 	ChatSession,
 	ChatAvailability,
 	ChatInitialState,
 	RawAttachment,
+	RawCitation,
 	RawMessage,
+	RawSource,
 	RawSession,
 	SessionMetadata,
 } from './types/index.ts';
@@ -28,6 +32,9 @@ export {
 
 // Normalizer
 export { normalizeMessage, normalizeConversation, normalizeSession } from './normalizer.ts';
+
+// Citations
+export { getMessageCitations, useMessageCitations } from './citations.ts';
 
 // Markdown
 export { markdownToHtml } from './markdown.ts';
@@ -131,6 +138,13 @@ export {
 	AvailabilityGate,
 	type AvailabilityGateProps,
 } from './components/AvailabilityGate.tsx';
+
+export {
+	CitationsList,
+	CitationBadge,
+	type CitationsListProps,
+	type CitationBadgeProps,
+} from './components/CitationsList.tsx';
 
 // Hooks
 export {

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -7,9 +7,9 @@
  * maps them into the package's role-based message model.
  */
 
-import type { ChatMessage, MediaAttachment, ToolCall } from './types/message.ts';
+import type { ChatCitation, ChatMessage, ChatSource, MediaAttachment, ToolCall } from './types/message.ts';
 import type { ChatSession } from './types/session.ts';
-import type { RawMessage, RawAttachment, RawSession } from './types/api.ts';
+import type { RawMessage, RawAttachment, RawCitation, RawSession, RawSource } from './types/api.ts';
 
 let idCounter = 0;
 function generateId(): string {
@@ -89,6 +89,11 @@ export function normalizeMessage(raw: RawMessage, index: number): ChatMessage {
 	const attachments = normalizeAttachments(raw);
 	if (attachments.length > 0) {
 		message.attachments = attachments;
+	}
+
+	const citations = normalizeCitations(raw);
+	if (citations.length > 0) {
+		message.citations = citations;
 	}
 
 	// Assistant messages may carry tool_calls at the top level
@@ -201,4 +206,57 @@ function normalizeAttachments(raw: RawMessage): MediaAttachment[] {
 	}
 
 	return attachments;
+}
+
+function normalizeCitations(raw: RawMessage): ChatCitation[] {
+	const rawCitations = raw.metadata?.citations;
+	if (!rawCitations?.length) return [];
+
+	const sourcesById = new Map<string, ChatSource>();
+	for (const rawSource of raw.metadata?.sources ?? []) {
+		const source = normalizeSource(rawSource);
+		if (source.id) {
+			sourcesById.set(source.id, source);
+		}
+	}
+
+	return rawCitations
+		.map((rawCitation) => normalizeCitation(rawCitation, sourcesById))
+		.filter((citation): citation is ChatCitation => citation !== null);
+}
+
+function normalizeCitation(raw: RawCitation, sourcesById: Map<string, ChatSource>): ChatCitation | null {
+	const source = raw.source
+		? normalizeSource(raw.source)
+		: raw.source_id
+			? sourcesById.get(raw.source_id) ?? normalizeSource({ ...raw, id: raw.source_id })
+			: normalizeSource(raw);
+
+	const citation: ChatCitation = {};
+	if (raw.id) citation.id = raw.id;
+	if (raw.index) citation.index = raw.index;
+	if (source && hasSourceData(source)) citation.source = source;
+	if (raw.snippet ?? raw.quote) citation.snippet = raw.snippet ?? raw.quote;
+	if (raw.url) citation.url = raw.url;
+	if (raw.metadata) citation.metadata = raw.metadata;
+
+	if (!citation.source && !citation.snippet && !citation.url && !citation.id) {
+		return null;
+	}
+
+	return citation;
+}
+
+function normalizeSource(raw: RawSource | RawCitation): ChatSource {
+	const source: ChatSource = {};
+	if (raw.id) source.id = raw.id;
+	if ('title' in raw && raw.title) source.title = raw.title;
+	if ('url' in raw && raw.url) source.url = raw.url;
+	if ('label' in raw && raw.label) source.label = raw.label;
+	if (raw.metadata) source.metadata = raw.metadata;
+	return source;
+}
+
+function hasSourceData(source: ChatSource): boolean {
+	return Boolean(source.id || source.title || source.url || source.label);
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,9 +1,8 @@
 /**
  * REST API contract types.
  *
- * These describe the expected shape of the chat REST endpoints.
- * Any backend that wants to work with this package implements
- * these same endpoints and response shapes.
+ * These describe the package's default endpoint shape. Adapters may normalize
+ * different backend responses into these structures before rendering.
  */
 
 /**
@@ -24,6 +23,27 @@ export interface RawAttachment {
 	thumbnail_url?: string;
 }
 
+export interface RawSource {
+	id?: string;
+	title?: string;
+	url?: string;
+	label?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface RawCitation {
+	id?: string;
+	index?: number;
+	source?: RawSource;
+	source_id?: string;
+	title?: string;
+	url?: string;
+	label?: string;
+	snippet?: string;
+	quote?: string;
+	metadata?: Record<string, unknown>;
+}
+
 export interface RawMessage {
 	role: 'user' | 'assistant';
 	content: string;
@@ -41,6 +61,10 @@ export interface RawMessage {
 		attachments?: RawAttachment[];
 		/** Media produced by tool results. */
 		media?: RawAttachment[];
+		/** Sources cited by this message. */
+		citations?: RawCitation[];
+		/** Source records that citations may reference by source_id. */
+		sources?: RawSource[];
 	};
 	tool_calls?: Array<{
 		id?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,8 @@ export type {
 	ToolCall,
 	ToolResultMeta,
 	MediaAttachment,
+	ChatCitation,
+	ChatSource,
 	ChatMessage,
 	ContentFormat,
 } from './message.ts';
@@ -15,7 +17,9 @@ export type {
 
 export type {
 	RawAttachment,
+	RawCitation,
 	RawMessage,
+	RawSource,
 	RawSession,
 	SendRequest,
 	SendResponse,

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -63,6 +63,40 @@ export interface MediaAttachment {
 }
 
 /**
+ * A source that a citation points to.
+ */
+export interface ChatSource {
+	/** Stable source identifier from the adapter or backend. */
+	id?: string;
+	/** Human-readable source title. */
+	title?: string;
+	/** Canonical source URL, when available. */
+	url?: string;
+	/** Source author, publisher, or container label. */
+	label?: string;
+	/** Arbitrary adapter metadata kept out of the rendering contract. */
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * A citation attached to a message.
+ */
+export interface ChatCitation {
+	/** Stable citation identifier from the adapter or backend. */
+	id?: string;
+	/** One-based display index. Consumers may omit it and let renderers derive one. */
+	index?: number;
+	/** Source data for the cited material. */
+	source?: ChatSource;
+	/** Cited quote or surrounding snippet. */
+	snippet?: string;
+	/** URL for this exact citation when it differs from the source URL. */
+	url?: string;
+	/** Arbitrary adapter metadata kept out of the rendering contract. */
+	metadata?: Record<string, unknown>;
+}
+
+/**
  * A single message in a chat conversation.
  */
 export interface ChatMessage {
@@ -80,6 +114,8 @@ export interface ChatMessage {
 	toolResult?: ToolResultMeta;
 	/** Media attachments (images, videos, files) on this message. */
 	attachments?: MediaAttachment[];
+	/** Citations or sources referenced by this message. */
+	citations?: ChatCitation[];
 	/** Client-side delivery state for optimistic messages. */
 	deliveryStatus?: 'queued' | 'failed';
 }


### PR DESCRIPTION
## Summary
- Adds backend-agnostic `ChatCitation` and `ChatSource` primitives plus raw citation/source metadata normalization.
- Adds `getMessageCitations`, `useMessageCitations`, `CitationsList`, and `CitationBadge` so assistant messages can render sources without product-specific consumer code.
- Keeps the contract generic for future adapter-driven consumers and avoids WordPress-, Extra Chill-, Intelligence-, or Frontend Agent Chat-specific naming.

Closes #45.

## Testing
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the typed citation/source primitives, default rendering components, normalization, verification, and PR drafting for Chris to review.