### PR TITLE
Add adapter-first chat envelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test test/*.test.mjs",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@
 import type { ChatMessage } from './types/message.ts';
 import type { ChatSession } from './types/session.ts';
 import type {
+	SendRequest,
 	SendResponse,
 	ContinueResponse,
 	ListSessionsResponse,
@@ -32,7 +33,7 @@ export interface FetchOptions {
 	path: string;
 	method?: string;
 	/** JSON body (mutually exclusive with formData). */
-	data?: Record<string, unknown>;
+	data?: unknown;
 	/** FormData body for file uploads (mutually exclusive with data). */
 	formData?: FormData;
 	/** Additional HTTP headers. */
@@ -42,11 +43,11 @@ export interface FetchOptions {
 export type FetchFn = (options: FetchOptions) => Promise<unknown>;
 
 export interface ChatApiConfig {
-	/** Base path for the chat endpoints (e.g. '/datamachine/v1/chat'). */
+	/** Base path for the chat endpoints. */
 	basePath: string;
 	/** The fetch function to use for requests. */
 	fetchFn: FetchFn;
-	/** Agent ID to scope sessions to. */
+	/** Optional adapter-level assistant identifier to scope sessions to. */
 	agentId?: number;
 }
 
@@ -69,6 +70,61 @@ export interface ContinueResult {
 	completed: boolean;
 	turnNumber: number;
 	maxTurnsReached: boolean;
+}
+
+export interface SendMessageInput {
+	content: string;
+	sessionId?: string;
+	attachments?: SendAttachment[];
+	metadata?: Record<string, unknown>;
+	clientContext?: Record<string, unknown>;
+}
+
+export interface ListSessionsInput {
+	limit?: number;
+	context?: string;
+}
+
+export interface CancelRunInput {
+	runId: string;
+	sessionId: string;
+}
+
+export interface QueueMessageInput extends SendMessageInput {
+	sessionId: string;
+	/** Active run this message should follow, when known. */
+	runId?: string;
+	files?: File[];
+}
+
+export interface QueueMessageResult {
+	/** Opaque ID assigned to the queued user message. */
+	queuedMessageId?: string;
+	/** Opaque ID for the queued or active run, when supplied by the adapter. */
+	runId?: string;
+	/** Zero-based or one-based queue position, as reported by the adapter. */
+	position?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export interface ChatRunCapabilities {
+	/** Whether the current backend adapter can cancel an active run. */
+	cancel?: boolean;
+	/** Whether the current backend adapter can queue follow-up messages. */
+	queue?: boolean;
+}
+
+export interface ChatAdapter {
+	runCapabilities?: ChatRunCapabilities;
+	sendMessage(input: SendMessageInput): Promise<SendResult>;
+	continueResponse(sessionId: string): Promise<ContinueResult>;
+	listSessions(input?: ListSessionsInput): Promise<ChatSession[]>;
+	loadSession(sessionId: string): Promise<ChatMessage[]>;
+	deleteSession(sessionId: string): Promise<void>;
+	markSessionRead?(sessionId: string): Promise<void>;
+	uploadFile?(file: File): Promise<{ url: string; media_id?: number }>;
+	cancelRun?(input: CancelRunInput): Promise<void> | void;
+	queueMessage?(input: QueueMessageInput): Promise<QueueMessageResult | void> | QueueMessageResult | void;
 }
 
 /**
@@ -101,6 +157,37 @@ export interface SendAttachment {
  */
 export type MediaUploadFn = (file: File) => Promise<{ url: string; media_id?: number }>;
 
+export function createSendMessageRequest(
+	config: ChatApiConfig,
+	input: SendMessageInput,
+): SendRequest {
+	const body: SendRequest = { message: input.content };
+	if (input.sessionId) body.session_id = input.sessionId;
+	if (config.agentId) body.agent_id = config.agentId;
+	if (input.attachments?.length) body.attachments = input.attachments;
+	if (input.metadata) body.metadata = input.metadata;
+	if (input.clientContext) body.clientContext = input.clientContext;
+	return body;
+}
+
+export function createRestChatAdapter(config: ChatApiConfig): ChatAdapter {
+	return {
+		sendMessage: (input) => sendMessage(
+			config,
+			input.content,
+			input.sessionId,
+			input.attachments,
+			input.metadata,
+			input.clientContext,
+		),
+		continueResponse: (sessionId) => continueResponse(config, sessionId),
+		listSessions: (input) => listSessions(config, input?.limit, input?.context),
+		loadSession: (sessionId) => loadSession(config, sessionId),
+		deleteSession: (sessionId) => deleteSession(config, sessionId),
+		markSessionRead: (sessionId) => markSessionRead(config, sessionId),
+	};
+}
+
 /**
  * Send a user message (create or continue a session).
  *
@@ -119,12 +206,15 @@ export async function sendMessage(
 	sessionId?: string,
 	attachments?: SendAttachment[],
 	metadata?: Record<string, unknown>,
+	clientContext?: Record<string, unknown>,
 ): Promise<SendResult> {
-	const body: Record<string, unknown> = { message: content };
-	if (sessionId) body.session_id = sessionId;
-	if (config.agentId) body.agent_id = config.agentId;
-	if (attachments?.length) body.attachments = attachments;
-	if (metadata) Object.assign(body, metadata);
+	const body = createSendMessageRequest(config, {
+		content,
+		sessionId,
+		attachments,
+		metadata,
+		clientContext,
+	});
 
 	// Generate a unique request ID for idempotent request handling.
 	const requestId = typeof crypto !== 'undefined' && crypto.randomUUID

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -3,22 +3,21 @@ import type { ChatMessage, ToolCall } from '../types/message.ts';
 import type { ChatSession } from '../types/session.ts';
 import type { ChatAvailability } from '../types/session.ts';
 import type { MediaAttachment } from '../types/message.ts';
-import type { FetchFn, ChatApiConfig, SendAttachment, MediaUploadFn } from '../api.ts';
+import type {
+	FetchFn,
+	SendAttachment,
+	MediaUploadFn,
+	ChatAdapter,
+	ChatRunCapabilities as AdapterChatRunCapabilities,
+	CancelRunInput as AdapterCancelRunInput,
+	QueueMessageInput as AdapterQueueMessageInput,
+	QueueMessageResult as AdapterQueueMessageResult,
+} from '../api.ts';
 import {
-	sendMessage as apiSendMessage,
-	continueResponse as apiContinueResponse,
-	listSessions as apiListSessions,
-	loadSession as apiLoadSession,
-	deleteSession as apiDeleteSession,
-	markSessionRead as apiMarkSessionRead,
+	createRestChatAdapter,
 } from '../api.ts';
 
-export interface ChatRunCapabilities {
-	/** Whether the current backend adapter can cancel an active run. */
-	cancel?: boolean;
-	/** Whether the current backend adapter can queue follow-up messages. */
-	queue?: boolean;
-}
+export type ChatRunCapabilities = AdapterChatRunCapabilities;
 
 export type ChatRunStatus = 'queued' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed';
 
@@ -31,40 +30,26 @@ export interface ChatRun {
 	metadata?: Record<string, unknown>;
 }
 
-export interface CancelRunInput {
-	runId: string;
-	sessionId: string;
-}
+export type CancelRunInput = AdapterCancelRunInput;
 
-export interface QueueMessageInput {
-	sessionId: string;
-	/** Active run this message should follow, when known. */
-	runId?: string;
-	content: string;
-	files?: File[];
-}
+export interface QueueMessageInput extends AdapterQueueMessageInput {}
 
-export interface QueueMessageResult extends Partial<ChatRun> {
-	/** Opaque ID assigned to the queued user message. */
-	queuedMessageId?: string;
-	/** Zero-based or one-based queue position, as reported by the adapter. */
-	position?: number;
-}
+export interface QueueMessageResult extends AdapterQueueMessageResult, Partial<ChatRun> {}
 
 /**
  * Configuration for the useChat hook.
  */
 export interface UseChatOptions {
+	/** Adapter that owns chat transport and backend-specific behavior. */
+	adapter?: ChatAdapter;
 	/**
-	 * Base path for the chat REST endpoints.
-	 * e.g. '/datamachine/v1/chat'
+	 * Base path for the default REST adapter. Required when `adapter` is not provided.
 	 */
-	basePath: string;
+	basePath?: string;
 	/**
-	 * Fetch function for API calls. Must accept { path, method?, data? }
-	 * and return parsed JSON. @wordpress/api-fetch works directly.
+	 * Fetch function for the default REST adapter. Required when `adapter` is not provided.
 	 */
-	fetchFn: FetchFn;
+	fetchFn?: FetchFn;
 	/**
 	 * Agent ID to scope the chat to.
 	 */
@@ -104,6 +89,8 @@ export interface UseChatOptions {
 	 * `{ post_id: 100, context: 'editor' }`).
 	 */
 	metadata?: Record<string, unknown>;
+	/** Client context forwarded separately from message metadata. */
+	clientContext?: Record<string, unknown>;
 	/**
 	 * Upload function for file attachments.
 	 *
@@ -242,6 +229,7 @@ function extractRunId(metadata: Record<string, unknown>): string | null {
  * ```
  */
 export function useChat({
+	adapter,
 	basePath,
 	fetchFn,
 	agentId,
@@ -253,6 +241,7 @@ export function useChat({
 	onToolCalls,
 	onResponseMetadata,
 	metadata,
+	clientContext,
 	mediaUploadFn,
 	runCapabilities,
 	activeRunId,
@@ -261,6 +250,14 @@ export function useChat({
 	onQueueMessage,
 	sessionContext,
 }: UseChatOptions): UseChatReturn {
+	const resolvedAdapter = adapter ?? (() => {
+		if (!basePath || !fetchFn) {
+			throw new Error('useChat requires either an adapter or both basePath and fetchFn');
+		}
+
+		return createRestChatAdapter({ basePath, fetchFn, agentId });
+	})();
+
 	const [messages, setMessages] = useState<ChatMessage[]>(initialMessages ?? []);
 	const [isLoading, setIsLoading] = useState(false);
 	const [isCancelling, setIsCancelling] = useState(false);
@@ -276,25 +273,26 @@ export function useChat({
 	const totalUnreadCount = sessions.reduce((sum, s) => sum + (s.unreadCount ?? 0), 0);
 	const activeSession = sessionId ? sessions.find((s) => s.id === sessionId) : undefined;
 	const unreadCount = activeSession?.unreadCount ?? 0;
-	const resolvedRunCapabilities = runCapabilities ?? {};
+	const adapterRef = useRef<ChatAdapter>(resolvedAdapter);
+	adapterRef.current = resolvedAdapter;
+	const resolvedRunCapabilities = runCapabilities ?? resolvedAdapter.runCapabilities ?? {};
+	const resolvedCancelRun = onCancelRun ?? resolvedAdapter.cancelRun;
+	const resolvedQueueMessage = onQueueMessage ?? resolvedAdapter.queueMessage;
+	const resolvedUploadFile = mediaUploadFn ?? resolvedAdapter.uploadFile;
 	const resolvedActiveRunId = activeRunId ?? metadataRunId;
 	const canCancelRun = !!(
 		isLoading &&
 		resolvedRunCapabilities.cancel &&
-		onCancelRun &&
+		resolvedCancelRun &&
 		resolvedActiveRunId &&
 		sessionId
 	);
 	const canQueueMessage = !!(
 		isLoading &&
 		resolvedRunCapabilities.queue &&
-		onQueueMessage &&
+		resolvedQueueMessage &&
 		sessionId
 	);
-
-	// Build API config from props
-	const configRef = useRef<ChatApiConfig>({ basePath, fetchFn, agentId });
-	configRef.current = { basePath, fetchFn, agentId };
 
 	const sessionIdRef = useRef(sessionId);
 	sessionIdRef.current = sessionId;
@@ -306,8 +304,10 @@ export function useChat({
 	onResponseMetadataRef.current = onResponseMetadata;
 	const metadataRef = useRef(metadata);
 	metadataRef.current = metadata;
-	const mediaUploadFnRef = useRef(mediaUploadFn);
-	mediaUploadFnRef.current = mediaUploadFn;
+	const clientContextRef = useRef(clientContext);
+	clientContextRef.current = clientContext;
+	const mediaUploadFnRef = useRef(resolvedUploadFile);
+	mediaUploadFnRef.current = resolvedUploadFile;
 	const runCapabilitiesRef = useRef(resolvedRunCapabilities);
 	runCapabilitiesRef.current = resolvedRunCapabilities;
 	const activeRunIdRef = useRef(resolvedActiveRunId);
@@ -315,9 +315,9 @@ export function useChat({
 	const getRunIdRef = useRef(getRunId);
 	getRunIdRef.current = getRunId;
 	const onCancelRunRef = useRef(onCancelRun);
-	onCancelRunRef.current = onCancelRun;
+	onCancelRunRef.current = resolvedCancelRun;
 	const onQueueMessageRef = useRef(onQueueMessage);
-	onQueueMessageRef.current = onQueueMessage;
+	onQueueMessageRef.current = resolvedQueueMessage;
 	const sessionContextRef = useRef(sessionContext);
 	sessionContextRef.current = sessionContext;
 	// Guard against concurrent session creation.
@@ -345,11 +345,10 @@ export function useChat({
 		const loadSessions = async () => {
 			setSessionsLoading(true);
 			try {
-				const list = await apiListSessions(
-					configRef.current,
-					20,
-					sessionContextRef.current,
-				);
+				const list = await adapterRef.current.listSessions({
+					limit: 20,
+					context: sessionContextRef.current,
+				});
 				setSessions(list);
 
 				const defaultSessionId = sessionIdRef.current ?? list[0]?.id ?? null;
@@ -357,7 +356,7 @@ export function useChat({
 					setSessionId(defaultSessionId);
 					sessionIdRef.current = defaultSessionId;
 
-					const loaded = await apiLoadSession(configRef.current, defaultSessionId);
+					const loaded = await adapterRef.current.loadSession(defaultSessionId);
 					setMessages(loaded);
 				}
 			} catch (err) {
@@ -414,6 +413,8 @@ export function useChat({
 					runId: activeRunId,
 					content,
 					files,
+					metadata: metadataRef.current,
+					clientContext: clientContextRef.current,
 				});
 				if (queued?.runId) {
 					setMetadataRunId(queued.runId);
@@ -503,13 +504,13 @@ export function useChat({
 		setProcessingSessionId(initiatingSessionId);
 
 		try {
-			const result = await apiSendMessage(
-				configRef.current,
+			const result = await adapterRef.current.sendMessage({
 				content,
-				sessionIdRef.current ?? undefined,
-				sendAttachments,
-				metadataRef.current,
-			);
+				sessionId: sessionIdRef.current ?? undefined,
+				attachments: sendAttachments,
+				metadata: metadataRef.current,
+				clientContext: clientContextRef.current,
+			});
 
 			if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) return;
 
@@ -538,10 +539,7 @@ export function useChat({
 					turns++;
 					setTurnCount(turns);
 
-					const continuation = await apiContinueResponse(
-						configRef.current,
-						result.sessionId,
-					);
+					const continuation = await adapterRef.current.continueResponse(result.sessionId);
 
 					if (cancelledRequestIdRef.current === requestId || activeRequestIdRef.current !== requestId) break;
 
@@ -562,7 +560,7 @@ export function useChat({
 			}
 
 			// Refresh sessions list after a message
-			apiListSessions(configRef.current, 20, sessionContextRef.current)
+			adapterRef.current.listSessions({ limit: 20, context: sessionContextRef.current })
 				.then(setSessions)
 				.catch(() => { /* ignore */ });
 
@@ -625,7 +623,7 @@ export function useChat({
 		setIsLoading(true);
 
 		try {
-			const loaded = await apiLoadSession(configRef.current, newSessionId);
+			const loaded = await adapterRef.current.loadSession(newSessionId);
 			setMessages(loaded);
 		} catch (err) {
 			onError?.(toError(err));
@@ -643,7 +641,7 @@ export function useChat({
 
 	const deleteSessionHandler = useCallback(async (targetSessionId: string) => {
 		try {
-			await apiDeleteSession(configRef.current, targetSessionId);
+			await adapterRef.current.deleteSession(targetSessionId);
 			setSessions((prev) => prev.filter((s) => s.id !== targetSessionId));
 
 			if (sessionIdRef.current === targetSessionId) {
@@ -672,7 +670,7 @@ export function useChat({
 		);
 
 		try {
-			await apiMarkSessionRead(configRef.current, currentSessionId);
+			await adapterRef.current.markSessionRead?.(currentSessionId);
 		} catch {
 			// Silently fail — next session list refresh will correct the count.
 		}
@@ -681,11 +679,10 @@ export function useChat({
 	const refreshSessions = useCallback(async () => {
 		setSessionsLoading(true);
 		try {
-			const list = await apiListSessions(
-				configRef.current,
-				20,
-				sessionContextRef.current,
-			);
+			const list = await adapterRef.current.listSessions({
+				limit: 20,
+				context: sessionContextRef.current,
+			});
 			setSessions(list);
 		} catch (err) {
 			onError?.(toError(err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,21 @@ export type {
 } from './types/index.ts';
 
 // API
-export type { FetchFn, FetchOptions, ChatApiConfig, SendResult, ContinueResult, SendAttachment, MediaUploadFn } from './api.ts';
+export type {
+	FetchFn,
+	FetchOptions,
+	ChatApiConfig,
+	ChatAdapter,
+	SendMessageInput,
+	ListSessionsInput,
+	SendResult,
+	ContinueResult,
+	SendAttachment,
+	MediaUploadFn,
+} from './api.ts';
 export {
+	createRestChatAdapter,
+	createSendMessageRequest,
 	sendMessage,
 	continueResponse,
 	listSessions,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -63,6 +63,10 @@ export interface SendRequest {
 		mime_type?: string;
 		filename?: string;
 	}>;
+	/** Consumer-defined metadata, kept separate from reserved request fields. */
+	metadata?: Record<string, unknown>;
+	/** Consumer-defined client context, kept separate from message metadata. */
+	clientContext?: Record<string, unknown>;
 }
 
 export interface SendResponse {

--- a/test/api.test.mjs
+++ b/test/api.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSendMessageRequest } from '../dist/api.js';
+
+test('createSendMessageRequest keeps metadata namespaced', () => {
+	const request = createSendMessageRequest(
+		{ basePath: '/chat', fetchFn: async () => ({}) },
+		{
+			content: 'hello',
+			sessionId: 'session-real',
+			attachments: [{ url: 'https://example.test/file.png', filename: 'file.png' }],
+			metadata: {
+				message: 'metadata message must not replace content',
+				session_id: 'metadata-session',
+				attachments: ['metadata attachment'],
+				custom: 42,
+			},
+			clientContext: {
+				viewport: 'desktop',
+			},
+		},
+	);
+
+	assert.equal(request.message, 'hello');
+	assert.equal(request.session_id, 'session-real');
+	assert.deepEqual(request.attachments, [{ url: 'https://example.test/file.png', filename: 'file.png' }]);
+	assert.deepEqual(request.metadata, {
+		message: 'metadata message must not replace content',
+		session_id: 'metadata-session',
+		attachments: ['metadata attachment'],
+		custom: 42,
+	});
+	assert.deepEqual(request.clientContext, { viewport: 'desktop' });
+});


### PR DESCRIPTION
## Summary
- Adds a backend-agnostic `ChatAdapter` contract for send, continue, session, read/delete, attachment upload, cancel, and queue behavior.
- Keeps existing `basePath + fetchFn` consumers working by wrapping them in the default REST adapter internally.
- Builds REST send requests with reserved fields, `metadata`, and `clientContext` separated so metadata cannot overwrite message/session/attachment fields.

Closes #44.

## Testing
- `npm test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the adapter-first contract, safe request envelope, and regression test; Chris remains responsible for review and acceptance.