### PR TITLE
Add floating chat shell and client context integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ npm install @extrachill/chat
 ```tsx
 import { Chat } from '@extrachill/chat';
 import '@extrachill/chat/css';
-import apiFetch from '@wordpress/api-fetch';
 
-function StudioChat() {
+function ChatSurface() {
   return (
     <Chat
-      basePath="/datamachine/v1/chat"
-      fetchFn={apiFetch}
-      agentId={5}
+      basePath="/chat"
+      fetchFn={fetchChatJson}
     />
   );
 }
@@ -28,7 +26,7 @@ function StudioChat() {
 
 ## What's Included
 
-**Components** — `Chat`, `ChatMessages`, `ChatMessage`, `ChatInput`, `TypingIndicator`, `ToolMessage`, `SessionSwitcher`, `ErrorBoundary`, `AvailabilityGate`
+**Components** — `Chat`, `FloatingChatShell`, `ChatMessages`, `ChatMessage`, `ChatInput`, `TypingIndicator`, `ToolMessage`, `SessionSwitcher`, `ErrorBoundary`, `AvailabilityGate`
 
 **Hook** — `useChat` manages messages, sessions, multi-turn continuation loops, and availability state
 
@@ -50,7 +48,7 @@ The package expects these endpoints at `basePath`:
 | `GET` | `/{session_id}` | Load a single session's conversation |
 | `DELETE` | `/{session_id}` | Delete a session |
 
-Any backend implementing this contract works. The `fetchFn` prop accepts any function matching `(options: { path, method?, data? }) => Promise<json>` — `@wordpress/api-fetch` works directly.
+Any backend implementing this contract works. The `fetchFn` prop accepts any function matching `(options: { path, method?, data? }) => Promise<json>`.
 
 ## Theming
 
@@ -71,9 +69,9 @@ Pass `messageSuggestions` to offer optional prompt starters on fresh conversatio
 
 ```tsx
 <Chat
-  basePath="/datamachine/v1/chat"
-  fetchFn={apiFetch}
-  messageSuggestions={[
+	basePath="/chat"
+	fetchFn={fetchChatJson}
+	messageSuggestions={[
     {
       label: 'Plan my homepage',
       message: 'Help me plan the homepage for my site.',
@@ -86,6 +84,56 @@ Pass `messageSuggestions` to offer optional prompt starters on fresh conversatio
   ]}
 />
 ```
+
+## Floating Shell
+
+Use `FloatingChatShell` when you want a launcher and floating drawer around the same backend-agnostic `Chat` component. The shell owns only visibility, expanded mode, unread badge state, and generic slots; product-specific UI should be supplied by the consumer.
+
+```tsx
+import { FloatingChatShell } from '@extrachill/chat';
+
+<FloatingChatShell
+  basePath="/chat"
+  fetchFn={fetchChatJson}
+  title="Assistant"
+  header={({ close }) => (
+    <div className="my-chat-header">
+      <strong>Assistant</strong>
+      <button type="button" onClick={close}>Close</button>
+    </div>
+  )}
+  launcher={({ toggleOpen, unreadCount }) => (
+    <button type="button" onClick={toggleOpen}>
+      Chat{unreadCount > 0 ? ` (${unreadCount})` : ''}
+    </button>
+  )}
+/>
+```
+
+You can also control the shell externally with `open`, `onOpenChange`, `expanded`, and `onExpandedChange`.
+
+## Client Context
+
+Register client-context providers when a surface has extra local state the backend may need. `Chat` includes that metadata only when `clientContext` is enabled, so existing inline usage is unchanged by default.
+
+```tsx
+import { Chat, registerClientContextProvider } from '@extrachill/chat';
+
+registerClientContextProvider({
+  id: 'current-document',
+  priority: 10,
+  getContext: () => ({ documentId: getCurrentDocumentId() }),
+});
+
+<Chat
+  basePath="/chat"
+  fetchFn={fetchChatJson}
+  clientContext
+  clientContextOptions={{ metadataKey: 'client_context' }}
+/>
+```
+
+Manual consumers can keep using `useClientContextMetadata()` and pass the result through `metadata` themselves.
 
 ## Long-Running Turns
 
@@ -127,12 +175,6 @@ The public TypeScript API uses camelCase (`runId`, `queuedMessageId`) while adap
 ```
 
 `onQueueMessage` may return `{ queuedMessageId, position, runId, sessionId, status }` when the adapter has an acknowledgement payload. The UI does not require those fields, but the types preserve them for adapters that want to coordinate follow-up polling or session refreshes.
-
-## Consumers
-
-- **extrachill-studio** — Studio Chat tab (agent_id=5)
-- **extrachill-roadie** — Portable floating agent chat
-- **data-machine** — Admin chat sidebar
 
 ## License
 

--- a/css/chat.css
+++ b/css/chat.css
@@ -79,6 +79,19 @@
 	--ec-chat-availability-bg: #f9fafb;
 	--ec-chat-availability-text: #374151;
 
+	/* Floating shell */
+	--ec-chat-shell-z-index: 9999;
+	--ec-chat-shell-offset: 24px;
+	--ec-chat-shell-width: 420px;
+	--ec-chat-shell-height: 640px;
+	--ec-chat-shell-expanded-width: min(960px, calc(100vw - 48px));
+	--ec-chat-shell-expanded-height: min(760px, calc(100vh - 48px));
+	--ec-chat-shell-shadow: 0 24px 80px rgba(15, 23, 42, 0.24);
+	--ec-chat-shell-launcher-bg: var(--ec-chat-send-bg);
+	--ec-chat-shell-launcher-text: var(--ec-chat-send-text);
+	--ec-chat-shell-badge-bg: #ef4444;
+	--ec-chat-shell-badge-text: #ffffff;
+
 	font-family: var(--ec-chat-font-family);
 	font-size: var(--ec-chat-font-size);
 	line-height: var(--ec-chat-line-height);
@@ -132,6 +145,7 @@
 
 		--ec-chat-availability-bg: #1e293b;
 		--ec-chat-availability-text: #cbd5e1;
+		--ec-chat-shell-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
 	}
 
 	.ec-chat-diff {
@@ -187,6 +201,190 @@
 	clip: rect(0, 0, 0, 0);
 	white-space: nowrap;
 	border: 0;
+}
+
+/* ============================================
+   Floating Shell
+   ============================================ */
+
+.ec-chat-shell {
+	--ec-chat-font-family: inherit;
+	--ec-chat-text: #1a1a1a;
+	--ec-chat-bg: #ffffff;
+	--ec-chat-border: #e5e7eb;
+	--ec-chat-input-bg: #ffffff;
+	--ec-chat-input-focus-border: #2563eb;
+	--ec-chat-session-hover-bg: #f9fafb;
+	--ec-chat-send-bg: #2563eb;
+	--ec-chat-send-text: #ffffff;
+	--ec-chat-border-radius: 12px;
+	--ec-chat-shell-z-index: 9999;
+	--ec-chat-shell-offset: 24px;
+	--ec-chat-shell-width: 420px;
+	--ec-chat-shell-height: 640px;
+	--ec-chat-shell-expanded-width: min(960px, calc(100vw - 48px));
+	--ec-chat-shell-expanded-height: min(760px, calc(100vh - 48px));
+	--ec-chat-shell-shadow: 0 24px 80px rgba(15, 23, 42, 0.24);
+	--ec-chat-shell-launcher-bg: var(--ec-chat-send-bg);
+	--ec-chat-shell-launcher-text: var(--ec-chat-send-text);
+	--ec-chat-shell-badge-bg: #ef4444;
+	--ec-chat-shell-badge-text: #ffffff;
+
+	position: fixed;
+	right: var(--ec-chat-shell-offset);
+	bottom: var(--ec-chat-shell-offset);
+	z-index: var(--ec-chat-shell-z-index);
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 12px;
+	font-family: var(--ec-chat-font-family);
+	color: var(--ec-chat-text);
+}
+
+@media (prefers-color-scheme: dark) {
+	.ec-chat-shell {
+		--ec-chat-text: #e2e8f0;
+		--ec-chat-bg: #1a1a2e;
+		--ec-chat-border: #334155;
+		--ec-chat-input-bg: #1e293b;
+		--ec-chat-input-focus-border: #3b82f6;
+		--ec-chat-session-hover-bg: #1e293b;
+		--ec-chat-send-bg: #3b82f6;
+		--ec-chat-send-text: #ffffff;
+		--ec-chat-shell-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+	}
+}
+
+.ec-chat-shell__launcher {
+	order: 2;
+}
+
+.ec-chat-shell__launcher-button {
+	appearance: none;
+	border: 0;
+	border-radius: 999px;
+	background: var(--ec-chat-shell-launcher-bg);
+	color: var(--ec-chat-shell-launcher-text);
+	box-shadow: var(--ec-chat-shell-shadow);
+	cursor: pointer;
+	font: inherit;
+	font-weight: 600;
+	min-height: 48px;
+	padding: 12px 18px;
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.ec-chat-shell__launcher-button:hover {
+	transform: translateY(-1px);
+}
+
+.ec-chat-shell__launcher-button:active {
+	transform: translateY(0);
+}
+
+.ec-chat-shell__badge {
+	background: var(--ec-chat-shell-badge-bg);
+	color: var(--ec-chat-shell-badge-text);
+	border-radius: 999px;
+	font-size: 12px;
+	font-weight: 700;
+	line-height: 1;
+	min-width: 20px;
+	padding: 4px 6px;
+	text-align: center;
+}
+
+.ec-chat-shell__panel {
+	order: 1;
+	width: min(var(--ec-chat-shell-width), calc(100vw - 32px));
+	height: min(var(--ec-chat-shell-height), calc(100vh - 96px));
+	background: var(--ec-chat-bg);
+	border: 1px solid var(--ec-chat-border);
+	border-radius: var(--ec-chat-border-radius);
+	box-shadow: var(--ec-chat-shell-shadow);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
+}
+
+.ec-chat-shell--expanded .ec-chat-shell__panel {
+	width: var(--ec-chat-shell-expanded-width);
+	height: var(--ec-chat-shell-expanded-height);
+}
+
+.ec-chat-shell__header {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 12px 14px;
+	border-bottom: 1px solid var(--ec-chat-border);
+	background: var(--ec-chat-bg);
+}
+
+.ec-chat-shell__title {
+	font-weight: 600;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.ec-chat-shell__actions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 8px;
+	min-width: 0;
+}
+
+.ec-chat-shell__control {
+	appearance: none;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 999px;
+	background: var(--ec-chat-input-bg);
+	color: var(--ec-chat-text);
+	cursor: pointer;
+	font: inherit;
+	font-size: 12px;
+	padding: 6px 10px;
+	transition: background-color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.ec-chat-shell__control:hover:not(:disabled) {
+	background: var(--ec-chat-session-hover-bg);
+	border-color: var(--ec-chat-input-focus-border);
+}
+
+.ec-chat-shell__chat {
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+@media (max-width: 640px) {
+	.ec-chat-shell {
+		right: 12px;
+		bottom: 12px;
+		left: 12px;
+		align-items: stretch;
+	}
+
+	.ec-chat-shell__launcher {
+		align-self: flex-end;
+	}
+
+	.ec-chat-shell__panel,
+	.ec-chat-shell--expanded .ec-chat-shell__panel {
+		width: 100%;
+		height: min(680px, calc(100vh - 88px));
+	}
 }
 
 /* ============================================

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -12,18 +12,50 @@ import { TypingIndicator } from './components/TypingIndicator.tsx';
 import { SessionSwitcher } from './components/SessionSwitcher.tsx';
 import { MessageSuggestions, type ChatMessageSuggestion } from './components/MessageSuggestions.tsx';
 import type { UseChatReturn } from './hooks/useChat.ts';
+import { useClientContextMetadata, type ClientContextMetadataOptions } from './client-context.ts';
 
 export type ChatSessionUi = 'list' | 'none';
+
+function mergeMetadata(
+	metadata: Record<string, unknown> | undefined,
+	additionalMetadata: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	const additionalKeys = Object.keys(additionalMetadata);
+	if (additionalKeys.length === 0) return metadata;
+	if (!metadata) return additionalMetadata;
+
+	const merged = { ...additionalMetadata, ...metadata };
+
+	for (const key of additionalKeys) {
+		const baseValue = additionalMetadata[key];
+		const overrideValue = metadata[key];
+		if (
+			baseValue &&
+			overrideValue &&
+			typeof baseValue === 'object' &&
+			typeof overrideValue === 'object' &&
+			!Array.isArray(baseValue) &&
+			!Array.isArray(overrideValue)
+		) {
+			merged[key] = {
+				...(baseValue as Record<string, unknown>),
+				...(overrideValue as Record<string, unknown>),
+			};
+		}
+	}
+
+	return merged;
+}
 
 export interface ChatProps {
 	/**
 	 * Base path for the chat REST endpoints.
-	 * e.g. '/datamachine/v1/chat'
+	 * e.g. '/chat'
 	 */
 	basePath: string;
 	/**
 	 * Fetch function for API calls. Must accept { path, method?, data? }
-	 * and return parsed JSON. @wordpress/api-fetch works directly.
+	 * and return parsed JSON.
 	 */
 	fetchFn: FetchFn;
 	/**
@@ -130,10 +162,8 @@ export interface ChatProps {
 	 * ```tsx
 	 * <Chat
 	 *   mediaUploadFn={async (file) => {
-	 *     const formData = new FormData();
-	 *     formData.append('file', file);
-	 *     const media = await apiFetch({ path: '/wp/v2/media', method: 'POST', body: formData });
-	 *     return { url: media.source_url, media_id: media.id };
+	 *     const media = await uploadMedia(file);
+	 *     return { url: media.url, media_id: media.id };
 	 *   }}
 	 * />
 	 * ```
@@ -156,6 +186,10 @@ export interface ChatProps {
 	 * Use for client-side context injection (e.g. `{ client_context: { tab: 'compose', postId: 123 } }`).
 	 */
 	metadata?: Record<string, unknown>;
+	/** Include registered client-context metadata with each sent message. Defaults to false. */
+	clientContext?: boolean;
+	/** Configure the automatically collected client-context metadata payload. */
+	clientContextOptions?: ClientContextMetadataOptions;
 	/** Deprecated: built-in copy transcript button UI is no longer rendered. */
 	showCopyTranscript?: boolean;
 	/** Deprecated legacy prop retained for compatibility. */
@@ -188,14 +222,12 @@ export interface ChatProps {
  * @example
  * ```tsx
  * import { Chat } from '@extrachill/chat';
- * import apiFetch from '@wordpress/api-fetch';
  *
- * function StudioChat() {
+ * function ChatSurface() {
  *   return (
  *     <Chat
- *       basePath="/datamachine/v1/chat"
- *       fetchFn={apiFetch}
- *       agentId={5}
+ *       basePath="/chat"
+ *       fetchFn={fetchChatJson}
  *     />
  *   );
  * }
@@ -239,6 +271,8 @@ export function Chat({
 	onQueueMessage,
 	cancelLabel,
 	metadata,
+	clientContext = false,
+	clientContextOptions,
 	showCopyTranscript = false,
 	copyTranscriptLabel,
 	copyTranscriptCopiedLabel,
@@ -248,6 +282,13 @@ export function Chat({
 }: ChatProps) {
 	// Attachments are only functional when a mediaUploadFn is provided.
 	const resolvedAllowAttachments = allowAttachments ?? !!mediaUploadFn;
+	const clientContextMetadata = useClientContextMetadata(clientContextOptions);
+	const resolvedMetadata = useMemo(
+		() => clientContext
+			? mergeMetadata(metadata, clientContextMetadata)
+			: metadata,
+		[clientContext, metadata, clientContextMetadata],
+	);
 
 	const chat = useChat({
 		basePath,
@@ -261,7 +302,7 @@ export function Chat({
 		onToolCalls,
 		onResponseMetadata,
 		sessionContext,
-		metadata,
+		metadata: resolvedMetadata,
 		mediaUploadFn,
 		runCapabilities,
 		activeRunId,

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@
  * implements the same endpoint shapes works out of the box.
  *
  * The `fetchFn` parameter allows consumers to plug in their own
- * fetch implementation (e.g. @wordpress/api-fetch for cookie auth).
+ * fetch implementation.
  */
 
 import type { ChatMessage } from './types/message.ts';
@@ -22,10 +22,7 @@ import { normalizeConversation, normalizeMessage, normalizeSession } from './nor
 /**
  * A fetch-like function. Accepts path + options, returns parsed JSON.
  *
- * This matches @wordpress/api-fetch signature:
- *   apiFetch({ path: '/datamachine/v1/chat', method: 'POST', data: {...} })
- *
- * For non-WordPress contexts, consumers wrap native fetch:
+ * Consumers can wrap native fetch:
  *   (opts) => fetch(baseUrl + opts.path, { method: opts.method, body: JSON.stringify(opts.data) }).then(r => r.json())
  */
 export interface FetchOptions {
@@ -42,7 +39,7 @@ export interface FetchOptions {
 export type FetchFn = (options: FetchOptions) => Promise<unknown>;
 
 export interface ChatApiConfig {
-	/** Base path for the chat endpoints (e.g. '/datamachine/v1/chat'). */
+	/** Base path for the chat endpoints (e.g. '/chat'). */
 	basePath: string;
 	/** The fetch function to use for requests. */
 	fetchFn: FetchFn;
@@ -85,17 +82,14 @@ export interface SendAttachment {
  * Upload function provided by the consumer to handle file uploads.
  *
  * Called for each file the user attaches before the chat message is sent.
- * Must upload the file to the consumer's storage (e.g. WordPress Media Library,
- * S3, etc.) and return a URL and/or media ID that the backend can resolve.
+ * Must upload the file to the consumer's storage and return a URL and/or media ID
+ * that the backend can resolve.
  *
  * @example
  * ```tsx
- * // WordPress consumer:
  * const mediaUploadFn: MediaUploadFn = async (file) => {
- *   const formData = new FormData();
- *   formData.append('file', file);
- *   const media = await apiFetch({ path: '/wp/v2/media', method: 'POST', body: formData });
- *   return { url: media.source_url, media_id: media.id };
+ *   const media = await uploadMedia(file);
+ *   return { url: media.url, media_id: media.id };
  * };
  * ```
  */
@@ -106,7 +100,7 @@ export type MediaUploadFn = (file: File) => Promise<{ url: string; media_id?: nu
  *
  * When attachments are provided, they are included in the JSON body
  * as structured metadata (not as file uploads — files should already
- * be in the WordPress media library or accessible by URL).
+ * be accessible by URL).
  *
  * @param metadata - Arbitrary key-value pairs forwarded to the backend
  *   alongside the message (e.g. `{ selected_pipeline_id: 42 }` or

--- a/src/client-context.ts
+++ b/src/client-context.ts
@@ -17,6 +17,17 @@ export interface ClientContextSnapshot {
 	providers: ClientContextProviderSnapshot[];
 }
 
+export interface ClientContextMetadataOptions {
+	/** Metadata key used for the client context payload. Defaults to `client_context`. */
+	metadataKey?: string;
+	/** Include browser location and document title. Defaults to true. */
+	includePage?: boolean;
+	/** Include the highest-priority provider context. Defaults to true. */
+	includeActiveContext?: boolean;
+	/** Include every registered provider context. Defaults to true. */
+	includeAvailableContexts?: boolean;
+}
+
 export interface ClientContextRegistry {
 	registerProvider: ( provider: ClientContextProvider ) => () => void;
 	unregisterProvider: ( id: string ) => void;
@@ -117,44 +128,72 @@ export function registerClientContextProvider( provider: ClientContextProvider )
 	return getOrCreateClientContextRegistry().registerProvider( provider );
 }
 
-export function getClientContextMetadata(): Record< string, unknown > {
+
+export function getClientContextMetadata( options: ClientContextMetadataOptions = {} ): Record< string, unknown > {
 	if ( typeof window === 'undefined' ) {
 		return {};
 	}
 
+	const {
+		metadataKey = 'client_context',
+		includePage = true,
+		includeActiveContext = true,
+		includeAvailableContexts = true,
+	} = options;
 	const snapshot = getOrCreateClientContextRegistry().getSnapshot();
+	const context: Record< string, unknown > = {};
 
-	return {
-		client_context: {
+	if ( includePage ) {
+		Object.assign( context, {
 			site: window.location.hostname,
 			url: window.location.href,
 			path: window.location.pathname,
 			page_title: document.title,
-			active_context: snapshot.activeContext,
-			available_contexts: snapshot.providers.map( ( provider ) => ( {
-				id: provider.id,
-				priority: provider.priority,
-				context: provider.context,
-			} ) ),
-		},
+		} );
+	}
+
+	if ( includeActiveContext ) {
+		context.active_context = snapshot.activeContext;
+	}
+
+	if ( includeAvailableContexts ) {
+		context.available_contexts = snapshot.providers.map( ( provider ) => ( {
+			id: provider.id,
+			priority: provider.priority,
+			context: provider.context,
+		} ) );
+	}
+
+	return {
+		[ metadataKey ]: context,
 	};
 }
 
-export function useClientContextMetadata(): Record< string, unknown > {
+export function useClientContextMetadata( options: ClientContextMetadataOptions = {} ): Record< string, unknown > {
 	const registry = useMemo( () => getOrCreateClientContextRegistry(), [] );
+	const metadataKey = options.metadataKey ?? 'client_context';
+	const includePage = options.includePage ?? true;
+	const includeActiveContext = options.includeActiveContext ?? true;
+	const includeAvailableContexts = options.includeAvailableContexts ?? true;
+	const resolvedOptions = useMemo( () => ( {
+		metadataKey,
+		includePage,
+		includeActiveContext,
+		includeAvailableContexts,
+	} ), [ metadataKey, includePage, includeActiveContext, includeAvailableContexts ] );
 	const [ metadata, setMetadata ] = useState< Record< string, unknown > >( () =>
-		getClientContextMetadata()
+		getClientContextMetadata( resolvedOptions )
 	);
 
 	useEffect( () => {
 		const sync = (): void => {
-			setMetadata( getClientContextMetadata() );
+			setMetadata( getClientContextMetadata( resolvedOptions ) );
 		};
 
 		sync();
 
 		return registry.subscribe( sync );
-	}, [ registry ] );
+	}, [ registry, resolvedOptions ] );
 
 	return metadata;
 }

--- a/src/components/FloatingChatShell.tsx
+++ b/src/components/FloatingChatShell.tsx
@@ -1,0 +1,187 @@
+import { type ReactNode, useId, useState } from 'react';
+import { Chat, type ChatProps } from '../Chat.tsx';
+
+export interface FloatingChatShellState {
+	open: boolean;
+	expanded: boolean;
+	unreadCount: number;
+	setOpen: ( open: boolean ) => void;
+	toggleOpen: () => void;
+	setExpanded: ( expanded: boolean ) => void;
+	toggleExpanded: () => void;
+	close: () => void;
+}
+
+export type FloatingChatShellSlot = ReactNode | ( ( state: FloatingChatShellState ) => ReactNode );
+
+export interface FloatingChatShellProps extends Omit< ChatProps, 'isVisible' | 'onUnreadChange' > {
+	/** Controlled open state. Omit to let the shell manage visibility. */
+	open?: boolean;
+	/** Initial open state for uncontrolled usage. Defaults to false. */
+	defaultOpen?: boolean;
+	/** Called when the shell requests an open state change. */
+	onOpenChange?: ( open: boolean ) => void;
+	/** Controlled expanded state. Omit to let the shell manage panel size. */
+	expanded?: boolean;
+	/** Initial expanded state for uncontrolled usage. Defaults to false. */
+	defaultExpanded?: boolean;
+	/** Called when the shell requests an expanded state change. */
+	onExpandedChange?: ( expanded: boolean ) => void;
+	/** Called whenever the composed Chat reports unread count changes. */
+	onUnreadChange?: ( totalUnread: number ) => void;
+	/** Additional CSS class name on the shell root. */
+	shellClassName?: string;
+	/** Additional CSS class name on the floating panel. */
+	panelClassName?: string;
+	/** Additional CSS class name on the launcher wrapper. */
+	launcherClassName?: string;
+	/** Optional title rendered in the default shell header. */
+	title?: ReactNode;
+	/** Custom launcher slot. Receives shell state when provided as a function. */
+	launcher?: FloatingChatShellSlot;
+	/** Custom header slot. Receives shell state when provided as a function. */
+	header?: FloatingChatShellSlot;
+	/** Custom actions slot rendered in the default header. */
+	actions?: FloatingChatShellSlot;
+	/** Accessible label for the default launcher. */
+	launcherLabel?: string;
+	/** Accessible label for the default close button. */
+	closeLabel?: string;
+	/** Accessible label for the default expand button. */
+	expandLabel?: string;
+	/** Accessible label for the default collapse button. */
+	collapseLabel?: string;
+}
+
+function renderSlot( slot: FloatingChatShellSlot | undefined, state: FloatingChatShellState ): ReactNode {
+	return typeof slot === 'function' ? slot( state ) : slot;
+}
+
+export function FloatingChatShell( {
+	open,
+	defaultOpen = false,
+	onOpenChange,
+	expanded,
+	defaultExpanded = false,
+	onExpandedChange,
+	onUnreadChange,
+	shellClassName,
+	panelClassName,
+	launcherClassName,
+	title = 'Chat',
+	launcher,
+	header,
+	actions,
+	launcherLabel = 'Open chat',
+	closeLabel = 'Close chat',
+	expandLabel = 'Expand chat',
+	collapseLabel = 'Collapse chat',
+	className,
+	...chatProps
+}: FloatingChatShellProps ) {
+	const panelId = useId();
+	const [ internalOpen, setInternalOpen ] = useState( defaultOpen );
+	const [ internalExpanded, setInternalExpanded ] = useState( defaultExpanded );
+	const [ unreadCount, setUnreadCount ] = useState( 0 );
+	const resolvedOpen = open ?? internalOpen;
+	const resolvedExpanded = expanded ?? internalExpanded;
+
+	const setOpen = ( nextOpen: boolean ): void => {
+		if ( open === undefined ) {
+			setInternalOpen( nextOpen );
+		}
+		onOpenChange?.( nextOpen );
+	};
+	const setExpanded = ( nextExpanded: boolean ): void => {
+		if ( expanded === undefined ) {
+			setInternalExpanded( nextExpanded );
+		}
+		onExpandedChange?.( nextExpanded );
+	};
+	const state: FloatingChatShellState = {
+		open: resolvedOpen,
+		expanded: resolvedExpanded,
+		unreadCount,
+		setOpen,
+		toggleOpen: () => setOpen( ! resolvedOpen ),
+		setExpanded,
+		toggleExpanded: () => setExpanded( ! resolvedExpanded ),
+		close: () => setOpen( false ),
+	};
+	const renderedLauncher = renderSlot( launcher, state );
+	const renderedHeader = renderSlot( header, state );
+	const renderedActions = renderSlot( actions, state );
+	const shellClasses = [
+		'ec-chat-shell',
+		resolvedOpen ? 'ec-chat-shell--open' : undefined,
+		resolvedExpanded ? 'ec-chat-shell--expanded' : undefined,
+		shellClassName,
+	].filter( Boolean ).join( ' ' );
+	const panelClasses = [ 'ec-chat-shell__panel', panelClassName ].filter( Boolean ).join( ' ' );
+	const chatClasses = [ 'ec-chat-shell__chat', className ].filter( Boolean ).join( ' ' );
+
+	return (
+		<div className={ shellClasses }>
+			<div className={ [ 'ec-chat-shell__launcher', launcherClassName ].filter( Boolean ).join( ' ' ) }>
+				{ renderedLauncher ?? (
+					<button
+						type="button"
+						className="ec-chat-shell__launcher-button"
+						aria-controls={ panelId }
+						aria-expanded={ resolvedOpen }
+						onClick={ state.toggleOpen }
+					>
+						<span>{ launcherLabel }</span>
+						{ unreadCount > 0 && (
+							<span className="ec-chat-shell__badge" aria-label={ `${ unreadCount } unread` }>
+								{ unreadCount }
+							</span>
+						) }
+					</button>
+				) }
+			</div>
+
+			<section
+				id={ panelId }
+				className={ panelClasses }
+				aria-label={ typeof title === 'string' ? title : 'Chat' }
+				hidden={ ! resolvedOpen }
+			>
+				{ renderedHeader ?? (
+					<div className="ec-chat-shell__header">
+						<div className="ec-chat-shell__title">{ title }</div>
+						<div className="ec-chat-shell__actions">
+							{ renderedActions }
+							<button
+								type="button"
+								className="ec-chat-shell__control"
+								onClick={ state.toggleExpanded }
+								aria-label={ resolvedExpanded ? collapseLabel : expandLabel }
+							>
+								{ resolvedExpanded ? 'Collapse' : 'Expand' }
+							</button>
+							<button
+								type="button"
+								className="ec-chat-shell__control"
+								onClick={ state.close }
+								aria-label={ closeLabel }
+							>
+								Close
+							</button>
+						</div>
+					</div>
+				) }
+
+				<Chat
+					{ ...chatProps }
+					className={ chatClasses }
+					isVisible={ resolvedOpen }
+					onUnreadChange={ ( totalUnread ) => {
+						setUnreadCount( totalUnread );
+						onUnreadChange?.( totalUnread );
+					} }
+				/>
+			</section>
+		</div>
+	);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export { SessionSwitcher, type SessionSwitcherProps } from './SessionSwitcher.ts
 export { MessageSuggestions, type ChatMessageSuggestion, type MessageSuggestionsProps } from './MessageSuggestions.tsx';
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.tsx';
 export { AvailabilityGate, type AvailabilityGateProps } from './AvailabilityGate.tsx';
+export { FloatingChatShell, type FloatingChatShellProps, type FloatingChatShellSlot, type FloatingChatShellState } from './FloatingChatShell.tsx';

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -57,12 +57,12 @@ export interface QueueMessageResult extends Partial<ChatRun> {
 export interface UseChatOptions {
 	/**
 	 * Base path for the chat REST endpoints.
-	 * e.g. '/datamachine/v1/chat'
+	 * e.g. '/chat'
 	 */
 	basePath: string;
 	/**
 	 * Fetch function for API calls. Must accept { path, method?, data? }
-	 * and return parsed JSON. @wordpress/api-fetch works directly.
+	 * and return parsed JSON.
 	 */
 	fetchFn: FetchFn;
 	/**
@@ -196,7 +196,7 @@ function generateMessageId(): string {
 /**
  * Extract a readable error message from any error shape.
  *
- * Handles Error instances, @wordpress/api-fetch error objects
+ * Handles Error instances, structured fetch error objects
  * ({ code, message, data }), and plain strings.
  */
 function toError(err: unknown): Error {
@@ -224,12 +224,9 @@ function extractRunId(metadata: Record<string, unknown>): string | null {
  *
  * @example
  * ```tsx
- * import apiFetch from '@wordpress/api-fetch';
- *
  * const chat = useChat({
- *   basePath: '/datamachine/v1/chat',
- *   fetchFn: apiFetch,
- *   agentId: 5,
+ *   basePath: '/chat',
+ *   fetchFn: fetchChatJson,
  * });
  *
  * return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export {
 	type ClientContextProviderSnapshot,
 	type ClientContextSnapshot,
 	type ClientContextRegistry,
+	type ClientContextMetadataOptions,
 } from './client-context.ts';
 
 // Components
@@ -131,6 +132,13 @@ export {
 	AvailabilityGate,
 	type AvailabilityGateProps,
 } from './components/AvailabilityGate.tsx';
+
+export {
+	FloatingChatShell,
+	type FloatingChatShellProps,
+	type FloatingChatShellSlot,
+	type FloatingChatShellState,
+} from './components/FloatingChatShell.tsx';
 
 // Hooks
 export {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -56,7 +56,7 @@ export interface MediaAttachment {
 	mimeType?: string;
 	/** File size in bytes. */
 	size?: number;
-	/** WordPress media library attachment ID. */
+	/** Consumer media library attachment ID. */
 	mediaId?: number;
 	/** Thumbnail URL for previews. */
 	thumbnailUrl?: string;


### PR DESCRIPTION
## Summary
- Adds a backend-agnostic `FloatingChatShell` wrapper with controlled/uncontrolled visibility, expanded mode, unread badge state, and generic launcher/header/action slots.
- Adds opt-in `clientContext` / `clientContextOptions` support to `Chat` so registered client-context providers are merged into outgoing message metadata without changing inline defaults.
- Updates public examples away from product-specific adapter names and documents the generic shell/client-context usage.

## Generic package boundary
- Keeps `@extrachill/chat` focused on reusable chat primitives and configuration.
- Does not add WordPress-, Extra Chill-, Intelligence-, or Frontend Agent Chat-specific contracts; consumers remain responsible for adapters, labels, styling, and product UI.

## Testing
- `npm run build`

Closes #49

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic floating shell, client-context integration, docs updates, and verification; Chris remains responsible for review and final acceptance.