### PR TITLE
Add run-control adapter primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @extrachill/chat
 
-React chat UI components with a built-in REST API client. Speaks the standard chat message format natively — no adapters, no wrappers.
+React chat UI components with a built-in REST API client and backend-agnostic extension primitives.
 
 ## Install
 
@@ -13,14 +13,12 @@ npm install @extrachill/chat
 ```tsx
 import { Chat } from '@extrachill/chat';
 import '@extrachill/chat/css';
-import apiFetch from '@wordpress/api-fetch';
 
-function StudioChat() {
+function AppChat() {
   return (
     <Chat
-      basePath="/datamachine/v1/chat"
-      fetchFn={apiFetch}
-      agentId={5}
+      basePath="/api/chat"
+      fetchFn={fetchChatJson}
     />
   );
 }
@@ -33,6 +31,8 @@ function StudioChat() {
 **Hook** — `useChat` manages messages, sessions, multi-turn continuation loops, and availability state
 
 **API client** — `sendMessage`, `continueResponse`, `listSessions`, `loadSession`, `deleteSession`
+
+**Run control** — `createRunControlAdapter`, `useRunEvents`, and typed run/event primitives for cancel, queue, status, and event access
 
 **Normalizer** — `normalizeMessage`, `normalizeConversation`, `normalizeSession` for mapping raw backend messages into the UI model
 
@@ -50,7 +50,7 @@ The package expects these endpoints at `basePath`:
 | `GET` | `/{session_id}` | Load a single session's conversation |
 | `DELETE` | `/{session_id}` | Delete a session |
 
-Any backend implementing this contract works. The `fetchFn` prop accepts any function matching `(options: { path, method?, data? }) => Promise<json>` — `@wordpress/api-fetch` works directly.
+Any backend implementing this contract works. The `fetchFn` prop accepts any function matching `(options: { path, method?, data? }) => Promise<json>`.
 
 ## Theming
 
@@ -71,8 +71,8 @@ Pass `messageSuggestions` to offer optional prompt starters on fresh conversatio
 
 ```tsx
 <Chat
-  basePath="/datamachine/v1/chat"
-  fetchFn={apiFetch}
+  basePath="/api/chat"
+  fetchFn={fetchChatJson}
   messageSuggestions={[
     {
       label: 'Plan my homepage',
@@ -92,8 +92,27 @@ Pass `messageSuggestions` to offer optional prompt starters on fresh conversatio
 Backends that support long-running chat turns can opt into stop and queue UI without changing the default behavior. When no capability is provided, the input is disabled while a response is loading, matching earlier releases.
 
 ```tsx
+const runAdapter = createRunControlAdapter({
+  basePath: '/api/chat',
+  fetchFn: fetchChatJson,
+  uploadFn: uploadAttachment,
+});
+
 <Chat
-  basePath="/chat"
+  basePath="/api/chat"
+  fetchFn={fetchChatJson}
+  initialSessionId="session-123"
+  runAdapter={runAdapter}
+/>
+```
+
+The adapter above uses generic REST-shaped run endpoints under `basePath`, exposes cancel/queue/status/events capabilities, uploads queued attachments through the supplied `uploadFn`, and normalizes event payloads into `ChatRunEvent` while preserving the raw event object.
+
+Existing manual props continue to work for consumers that already own backend-specific callbacks:
+
+```tsx
+<Chat
+  basePath="/api/chat"
   fetchFn={fetchChatJson}
   initialSessionId="session-123"
   runCapabilities={{ cancel: true, queue: true }}
@@ -118,7 +137,7 @@ The public TypeScript API uses camelCase (`runId`, `queuedMessageId`) while adap
 
 ```tsx
 <Chat
-  basePath="/chat"
+  basePath="/api/chat"
   fetchFn={fetchChatJson}
   runCapabilities={{ cancel: true }}
   getRunId={(metadata) => typeof metadata.run_id === 'string' ? metadata.run_id : null}
@@ -128,11 +147,16 @@ The public TypeScript API uses camelCase (`runId`, `queuedMessageId`) while adap
 
 `onQueueMessage` may return `{ queuedMessageId, position, runId, sessionId, status }` when the adapter has an acknowledgement payload. The UI does not require those fields, but the types preserve them for adapters that want to coordinate follow-up polling or session refreshes.
 
-## Consumers
+Run events can be consumed independently from the UI:
 
-- **extrachill-studio** — Studio Chat tab (agent_id=5)
-- **extrachill-roadie** — Portable floating agent chat
-- **data-machine** — Admin chat sidebar
+```tsx
+const { events, refresh } = useRunEvents({
+  adapter: runAdapter,
+  runId,
+  sessionId,
+  intervalMs: 2000,
+});
+```
 
 ## License
 

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 import type { ChatMessage as ChatMessageType, ContentFormat, ToolCall } from './types/index.ts';
 import type { FetchFn, MediaUploadFn } from './api.ts';
+import type { ChatRunAdapter } from './run-control.ts';
 import type { ToolRenderer } from './components/ToolMessage.tsx';
 import { useChat, type UseChatOptions } from './hooks/useChat.ts';
 import { useLoadingMessages, type LoadingMessagesConfig } from './hooks/useLoadingMessages.ts';
@@ -18,12 +19,12 @@ export type ChatSessionUi = 'list' | 'none';
 export interface ChatProps {
 	/**
 	 * Base path for the chat REST endpoints.
-	 * e.g. '/datamachine/v1/chat'
+	 * e.g. '/api/chat'
 	 */
 	basePath: string;
 	/**
 	 * Fetch function for API calls. Must accept { path, method?, data? }
-	 * and return parsed JSON. @wordpress/api-fetch works directly.
+	 * and return parsed JSON.
 	 */
 	fetchFn: FetchFn;
 	/**
@@ -126,19 +127,12 @@ export interface ChatProps {
 	 * Must upload the file and return a URL and/or media ID.
 	 * When not provided, the attach button is hidden.
 	 *
-	 * @example
-	 * ```tsx
-	 * <Chat
-	 *   mediaUploadFn={async (file) => {
-	 *     const formData = new FormData();
-	 *     formData.append('file', file);
-	 *     const media = await apiFetch({ path: '/wp/v2/media', method: 'POST', body: formData });
-	 *     return { url: media.source_url, media_id: media.id };
-	 *   }}
-	 * />
-	 * ```
+	 * The upload function is owned by the consumer because storage and
+	 * authorization are backend-specific.
 	 */
 	mediaUploadFn?: MediaUploadFn;
+	/** Optional adapter that supplies long-running turn controls. */
+	runAdapter?: ChatRunAdapter;
 	/** Optional long-running turn capabilities supplied by the backend adapter. */
 	runCapabilities?: UseChatOptions['runCapabilities'];
 	/** Active backend run ID, when the adapter already knows it. */
@@ -153,7 +147,7 @@ export interface ChatProps {
 	cancelLabel?: string;
 	/**
 	 * Arbitrary metadata forwarded to the backend with each message.
-	 * Use for client-side context injection (e.g. `{ client_context: { tab: 'compose', postId: 123 } }`).
+	 * Use for client-side context injection (e.g. `{ clientContext: { tab: 'compose' } }`).
 	 */
 	metadata?: Record<string, unknown>;
 	/** Deprecated: built-in copy transcript button UI is no longer rendered. */
@@ -188,14 +182,11 @@ export interface ChatProps {
  * @example
  * ```tsx
  * import { Chat } from '@extrachill/chat';
- * import apiFetch from '@wordpress/api-fetch';
- *
- * function StudioChat() {
+ * function AppChat() {
  *   return (
  *     <Chat
- *       basePath="/datamachine/v1/chat"
- *       fetchFn={apiFetch}
- *       agentId={5}
+ *       basePath="/api/chat"
+ *       fetchFn={fetchChatJson}
  *     />
  *   );
  * }
@@ -232,6 +223,7 @@ export function Chat({
 	allowAttachments,
 	acceptFileTypes,
 	mediaUploadFn,
+	runAdapter,
 	runCapabilities,
 	activeRunId,
 	getRunId,
@@ -263,6 +255,7 @@ export function Chat({
 		sessionContext,
 		metadata,
 		mediaUploadFn,
+		runAdapter,
 		runCapabilities,
 		activeRunId,
 		getRunId,

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@
  * implements the same endpoint shapes works out of the box.
  *
  * The `fetchFn` parameter allows consumers to plug in their own
- * fetch implementation (e.g. @wordpress/api-fetch for cookie auth).
+ * authenticated fetch implementation.
  */
 
 import type { ChatMessage } from './types/message.ts';
@@ -23,10 +23,7 @@ import { normalizeConversation, normalizeMessage, normalizeSession } from './nor
 /**
  * A fetch-like function. Accepts path + options, returns parsed JSON.
  *
- * This matches @wordpress/api-fetch signature:
- *   apiFetch({ path: '/datamachine/v1/chat', method: 'POST', data: {...} })
- *
- * For non-WordPress contexts, consumers wrap native fetch:
+ * Consumers can wrap native fetch:
  *   (opts) => fetch(baseUrl + opts.path, { method: opts.method, body: JSON.stringify(opts.data) }).then(r => r.json())
  */
 export interface FetchOptions {
@@ -43,7 +40,7 @@ export interface FetchOptions {
 export type FetchFn = (options: FetchOptions) => Promise<unknown>;
 
 export interface ChatApiConfig {
-	/** Base path for the chat endpoints. */
+	/** Base path for the chat endpoints (e.g. '/api/chat'). */
 	basePath: string;
 	/** The fetch function to use for requests. */
 	fetchFn: FetchFn;
@@ -102,8 +99,14 @@ export interface QueueMessageResult {
 	queuedMessageId?: string;
 	/** Opaque ID for the queued or active run, when supplied by the adapter. */
 	runId?: string;
+	/** Session ID associated with the queued message, when supplied by the adapter. */
+	sessionId?: string;
+	/** Status for the queued or active run, when supplied by the adapter. */
+	status?: 'queued' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed';
 	/** Zero-based or one-based queue position, as reported by the adapter. */
 	position?: number;
+	startedAt?: string;
+	updatedAt?: string;
 	metadata?: Record<string, unknown>;
 }
 
@@ -112,6 +115,10 @@ export interface ChatRunCapabilities {
 	cancel?: boolean;
 	/** Whether the current backend adapter can queue follow-up messages. */
 	queue?: boolean;
+	/** Whether the current backend adapter can read run status. */
+	status?: boolean;
+	/** Whether the current backend adapter can read run events. */
+	events?: boolean;
 }
 
 export interface ChatAdapter {
@@ -141,19 +148,8 @@ export interface SendAttachment {
  * Upload function provided by the consumer to handle file uploads.
  *
  * Called for each file the user attaches before the chat message is sent.
- * Must upload the file to the consumer's storage (e.g. WordPress Media Library,
- * S3, etc.) and return a URL and/or media ID that the backend can resolve.
- *
- * @example
- * ```tsx
- * // WordPress consumer:
- * const mediaUploadFn: MediaUploadFn = async (file) => {
- *   const formData = new FormData();
- *   formData.append('file', file);
- *   const media = await apiFetch({ path: '/wp/v2/media', method: 'POST', body: formData });
- *   return { url: media.source_url, media_id: media.id };
- * };
- * ```
+ * Must upload the file to the consumer's storage and return a URL
+ * and/or media ID that the backend can resolve.
  */
 export type MediaUploadFn = (file: File) => Promise<{ url: string; media_id?: number }>;
 
@@ -193,11 +189,11 @@ export function createRestChatAdapter(config: ChatApiConfig): ChatAdapter {
  *
  * When attachments are provided, they are included in the JSON body
  * as structured metadata (not as file uploads — files should already
- * be in the WordPress media library or accessible by URL).
+ * be available to the backend by URL or ID).
  *
  * @param metadata - Arbitrary key-value pairs forwarded to the backend
- *   alongside the message (e.g. `{ selected_pipeline_id: 42 }` or
- *   `{ post_id: 100, context: 'editor' }`). The backend can use these
+ *   alongside the message (e.g. `{ projectId: 42 }` or
+ *   `{ context: 'editor' }`). The backend can use these
  *   to scope the AI's behavior. Not persisted as message content.
  */
 export async function sendMessage(

--- a/src/components/DiffCard.tsx
+++ b/src/components/DiffCard.tsx
@@ -35,7 +35,7 @@ type DiffCardStatus = 'pending' | 'accepted' | 'rejected';
  * Portable diff visualization card.
  *
  * Renders a before/after comparison with word-level `<ins>` / `<del>` tags
- * and Accept / Reject buttons. Pure React — no Gutenberg or WordPress
+ * and Accept / Reject buttons. Pure React with no host application
  * dependencies. Works anywhere `@extrachill/chat` is consumed.
  *
  * @example

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export {
 	useChat,
 	type ChatRun,
+	type ChatRunAdapter,
 	type CancelRunInput,
 	type ChatRunCapabilities,
 	type ChatRunStatus,
@@ -9,6 +10,11 @@ export {
 	type UseChatOptions,
 	type UseChatReturn,
 } from './useChat.ts';
+export {
+	useRunEvents,
+	type UseRunEventsOptions,
+	type UseRunEventsReturn,
+} from './useRunEvents.ts';
 export {
 	useLoadingMessages,
 	DEFAULT_LOADING_MESSAGES,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -8,33 +8,27 @@ import type {
 	SendAttachment,
 	MediaUploadFn,
 	ChatAdapter,
-	ChatRunCapabilities as AdapterChatRunCapabilities,
-	CancelRunInput as AdapterCancelRunInput,
-	QueueMessageInput as AdapterQueueMessageInput,
-	QueueMessageResult as AdapterQueueMessageResult,
+	ChatRunCapabilities,
+	CancelRunInput,
+	QueueMessageInput,
+	QueueMessageResult,
 } from '../api.ts';
+import type { ChatRun, ChatRunAdapter, ChatRunStatus } from '../run-control.ts';
 import {
 	createRestChatAdapter,
 } from '../api.ts';
 
-export type ChatRunCapabilities = AdapterChatRunCapabilities;
-
-export type ChatRunStatus = 'queued' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed';
-
-export interface ChatRun {
-	runId: string;
-	sessionId: string;
-	status?: ChatRunStatus;
-	startedAt?: string;
-	updatedAt?: string;
-	metadata?: Record<string, unknown>;
-}
-
-export type CancelRunInput = AdapterCancelRunInput;
-
-export interface QueueMessageInput extends AdapterQueueMessageInput {}
-
-export interface QueueMessageResult extends AdapterQueueMessageResult, Partial<ChatRun> {}
+export type {
+	ChatRun,
+	ChatRunAdapter,
+	ChatRunStatus,
+} from '../run-control.ts';
+export type {
+	CancelRunInput,
+	ChatRunCapabilities,
+	QueueMessageInput,
+	QueueMessageResult,
+} from '../api.ts';
 
 /**
  * Configuration for the useChat hook.
@@ -85,8 +79,8 @@ export interface UseChatOptions {
 	onResponseMetadata?: (metadata: Record<string, unknown>) => void;
 	/**
 	 * Arbitrary metadata forwarded to the backend with each message.
-	 * Use for context scoping (e.g. `{ selected_pipeline_id: 42 }`,
-	 * `{ post_id: 100, context: 'editor' }`).
+	 * Use for context scoping (e.g. `{ projectId: 42 }`,
+	 * `{ context: 'editor' }`).
 	 */
 	metadata?: Record<string, unknown>;
 	/** Client context forwarded separately from message metadata. */
@@ -101,6 +95,8 @@ export interface UseChatOptions {
 	 * in the composed Chat component) because files cannot be processed.
 	 */
 	mediaUploadFn?: MediaUploadFn;
+	/** Optional adapter that supplies long-running turn controls. */
+	runAdapter?: ChatRunAdapter;
 	/** Optional long-running turn capabilities supplied by the backend adapter. */
 	runCapabilities?: ChatRunCapabilities;
 	/** Active backend run ID, when the adapter already knows it. */
@@ -183,7 +179,7 @@ function generateMessageId(): string {
 /**
  * Extract a readable error message from any error shape.
  *
- * Handles Error instances, @wordpress/api-fetch error objects
+ * Handles Error instances, fetch error objects
  * ({ code, message, data }), and plain strings.
  */
 function toError(err: unknown): Error {
@@ -211,12 +207,9 @@ function extractRunId(metadata: Record<string, unknown>): string | null {
  *
  * @example
  * ```tsx
- * import apiFetch from '@wordpress/api-fetch';
- *
  * const chat = useChat({
- *   basePath: '/datamachine/v1/chat',
- *   fetchFn: apiFetch,
- *   agentId: 5,
+ *   basePath: '/api/chat',
+ *   fetchFn: fetchChatJson,
  * });
  *
  * return (
@@ -243,6 +236,7 @@ export function useChat({
 	metadata,
 	clientContext,
 	mediaUploadFn,
+	runAdapter,
 	runCapabilities,
 	activeRunId,
 	getRunId,
@@ -275,11 +269,12 @@ export function useChat({
 	const unreadCount = activeSession?.unreadCount ?? 0;
 	const adapterRef = useRef<ChatAdapter>(resolvedAdapter);
 	adapterRef.current = resolvedAdapter;
-	const resolvedRunCapabilities = runCapabilities ?? resolvedAdapter.runCapabilities ?? {};
-	const resolvedCancelRun = onCancelRun ?? resolvedAdapter.cancelRun;
-	const resolvedQueueMessage = onQueueMessage ?? resolvedAdapter.queueMessage;
+	const resolvedRunCapabilities = runCapabilities ?? runAdapter?.capabilities ?? resolvedAdapter.runCapabilities ?? {};
+	const resolvedCancelRun = onCancelRun ?? runAdapter?.cancel ?? resolvedAdapter.cancelRun;
+	const resolvedQueueMessage = onQueueMessage ?? runAdapter?.queue ?? resolvedAdapter.queueMessage;
 	const resolvedUploadFile = mediaUploadFn ?? resolvedAdapter.uploadFile;
-	const resolvedActiveRunId = activeRunId ?? metadataRunId;
+	const resolvedActiveRunId = activeRunId ?? runAdapter?.activeRunId ?? metadataRunId;
+	const resolvedGetRunId = getRunId ?? runAdapter?.getRunId;
 	const canCancelRun = !!(
 		isLoading &&
 		resolvedRunCapabilities.cancel &&
@@ -312,11 +307,11 @@ export function useChat({
 	runCapabilitiesRef.current = resolvedRunCapabilities;
 	const activeRunIdRef = useRef(resolvedActiveRunId);
 	activeRunIdRef.current = resolvedActiveRunId;
-	const getRunIdRef = useRef(getRunId);
-	getRunIdRef.current = getRunId;
-	const onCancelRunRef = useRef(onCancelRun);
+	const getRunIdRef = useRef(resolvedGetRunId);
+	getRunIdRef.current = resolvedGetRunId;
+	const onCancelRunRef = useRef(resolvedCancelRun);
 	onCancelRunRef.current = resolvedCancelRun;
-	const onQueueMessageRef = useRef(onQueueMessage);
+	const onQueueMessageRef = useRef(resolvedQueueMessage);
 	onQueueMessageRef.current = resolvedQueueMessage;
 	const sessionContextRef = useRef(sessionContext);
 	sessionContextRef.current = sessionContext;
@@ -454,7 +449,7 @@ export function useChat({
 
 			// Upload files via the consumer's upload function, or fall back
 			// to metadata-only attachments (which the backend will reject
-			// without a url/media_id).
+			// without a URL or backend-resolvable ID).
 			const uploadFn = mediaUploadFnRef.current;
 			if (uploadFn) {
 				try {

--- a/src/hooks/useRunEvents.ts
+++ b/src/hooks/useRunEvents.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CancelRunInput, ChatRunAdapter, ChatRunEvent } from '../run-control.ts';
+
+export interface UseRunEventsOptions extends Partial<CancelRunInput> {
+	adapter?: ChatRunAdapter;
+	enabled?: boolean;
+	intervalMs?: number;
+	onEvents?: (events: ChatRunEvent[]) => void;
+	onError?: (error: Error) => void;
+}
+
+export interface UseRunEventsReturn {
+	events: ChatRunEvent[];
+	isLoading: boolean;
+	error: Error | null;
+	refresh: () => Promise<void>;
+}
+
+function toError(err: unknown): Error {
+	if (err instanceof Error) return err;
+	if (typeof err === 'string') return new Error(err);
+	return new Error('Failed to load run events');
+}
+
+export function useRunEvents({
+	adapter,
+	runId,
+	sessionId,
+	enabled = true,
+	intervalMs,
+	onEvents,
+	onError,
+}: UseRunEventsOptions): UseRunEventsReturn {
+	const [events, setEvents] = useState<ChatRunEvent[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<Error | null>(null);
+	const onEventsRef = useRef(onEvents);
+	const onErrorRef = useRef(onError);
+	onEventsRef.current = onEvents;
+	onErrorRef.current = onError;
+
+	const refresh = useCallback(async () => {
+		if (!enabled || !adapter?.listEvents || !runId || !sessionId) return;
+
+		setIsLoading(true);
+		try {
+			const nextEvents = await adapter.listEvents({ runId, sessionId });
+			setEvents(nextEvents);
+			setError(null);
+			onEventsRef.current?.(nextEvents);
+		} catch (err) {
+			const nextError = toError(err);
+			setError(nextError);
+			onErrorRef.current?.(nextError);
+		} finally {
+			setIsLoading(false);
+		}
+	}, [adapter, enabled, runId, sessionId]);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	useEffect(() => {
+		if (!intervalMs || intervalMs <= 0) return;
+		const timer = window.setInterval(() => {
+			refresh();
+		}, intervalMs);
+		return () => window.clearInterval(timer);
+	}, [intervalMs, refresh]);
+
+	return { events, isLoading, error, refresh };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,23 @@ export {
 	type ClientContextRegistry,
 } from './client-context.ts';
 
+// Run control
+export {
+	createRunControlAdapter,
+	normalizeRunEvent,
+	type CancelRunInput,
+	type ChatRun,
+	type ChatRunAdapter,
+	type ChatRunAttachment,
+	type ChatRunCapabilities,
+	type ChatRunEvent,
+	type ChatRunStatus,
+	type ChatRunUploadFn,
+	type QueueMessageInput,
+	type QueueMessageResult,
+	type RunControlAdapterOptions,
+} from './run-control.ts';
+
 // Components
 export {
 	ChatMessage as ChatMessageComponent,
@@ -189,15 +206,15 @@ export {
 // Hooks
 export {
 	useChat,
-	type ChatRun,
-	type CancelRunInput,
-	type ChatRunCapabilities,
-	type ChatRunStatus,
-	type QueueMessageInput,
-	type QueueMessageResult,
 	type UseChatOptions,
 	type UseChatReturn,
 } from './hooks/useChat.ts';
+
+export {
+	useRunEvents,
+	type UseRunEventsOptions,
+	type UseRunEventsReturn,
+} from './hooks/useRunEvents.ts';
 
 export {
 	useLoadingMessages,

--- a/src/run-control.ts
+++ b/src/run-control.ts
@@ -1,0 +1,207 @@
+import type { CancelRunInput, ChatRunCapabilities, FetchFn, QueueMessageInput, QueueMessageResult } from './api.ts';
+
+export type { CancelRunInput, ChatRunCapabilities, QueueMessageInput, QueueMessageResult } from './api.ts';
+
+export type ChatRunStatus = 'queued' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed';
+
+export interface ChatRun {
+	runId: string;
+	sessionId: string;
+	status?: ChatRunStatus;
+	startedAt?: string;
+	updatedAt?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface ChatRunEvent {
+	/** Stable event ID, when supplied by the backend. */
+	id?: string;
+	/** Run this event belongs to. */
+	runId: string;
+	/** Session this event belongs to, when supplied by the backend. */
+	sessionId?: string;
+	/** Backend-agnostic event type, such as `status`, `message`, or `tool`. */
+	type: string;
+	/** Run status associated with the event, when present. */
+	status?: ChatRunStatus;
+	/** Human-readable event message, when present. */
+	message?: string;
+	/** Event creation time as an ISO string, when supplied by the backend. */
+	createdAt?: string;
+	/** Monotonic event position, when supplied by the backend. */
+	sequence?: number;
+	/** Event-specific data normalized by the adapter. */
+	metadata?: Record<string, unknown>;
+	/** Original event object for consumers that need backend-specific fields. */
+	raw: Record<string, unknown>;
+}
+
+export interface ChatRunAdapter {
+	capabilities?: ChatRunCapabilities;
+	activeRunId?: string | null;
+	getRunId?: (metadata: Record<string, unknown>) => string | null | undefined;
+	cancel?: (input: CancelRunInput) => Promise<void> | void;
+	queue?: (input: QueueMessageInput) => Promise<QueueMessageResult | void> | QueueMessageResult | void;
+	getStatus?: (input: CancelRunInput) => Promise<ChatRun | null>;
+	listEvents?: (input: CancelRunInput) => Promise<ChatRunEvent[]>;
+}
+
+export interface ChatRunAttachment {
+	id?: string | number;
+	url?: string;
+	mimeType?: string;
+	filename?: string;
+	size?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export type ChatRunUploadFn = (file: File) => Promise<ChatRunAttachment>;
+
+export interface RunControlAdapterOptions {
+	fetchFn: FetchFn;
+	/** Base path for run-control endpoints, for example `/api/chat`. */
+	basePath: string;
+	uploadFn?: ChatRunUploadFn;
+}
+
+function compactPath(path: string): string {
+	return path.replace(/\/+/g, '/').replace(':/', '://');
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function dataRecord(value: unknown): Record<string, unknown> {
+	const record = asRecord(value);
+	return asRecord(record.data ?? record);
+}
+
+function stringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === 'string' && value.trim()) return value;
+	}
+	return undefined;
+}
+
+function numberField(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === 'number') return value;
+	}
+	return undefined;
+}
+
+function statusField(record: Record<string, unknown>): ChatRunStatus | undefined {
+	const status = stringField(record, 'status');
+	return status === 'queued' || status === 'running' || status === 'cancelling' ||
+		status === 'cancelled' || status === 'completed' || status === 'failed'
+		? status
+		: undefined;
+}
+
+function normalizeRun(record: Record<string, unknown>, fallback: CancelRunInput): ChatRun | null {
+	const runId = stringField(record, 'runId', 'run_id') ?? fallback.runId;
+	const sessionId = stringField(record, 'sessionId', 'session_id') ?? fallback.sessionId;
+	if (!runId || !sessionId) return null;
+
+	return {
+		runId,
+		sessionId,
+		status: statusField(record),
+		startedAt: stringField(record, 'startedAt', 'started_at'),
+		updatedAt: stringField(record, 'updatedAt', 'updated_at'),
+		metadata: asRecord(record.metadata),
+	};
+}
+
+export function normalizeRunEvent(value: unknown, fallbackRunId?: string): ChatRunEvent | null {
+	const record = asRecord(value);
+	const runId = stringField(record, 'runId', 'run_id') ?? fallbackRunId;
+	const type = stringField(record, 'type', 'event') ?? 'event';
+	if (!runId) return null;
+
+	return {
+		id: stringField(record, 'id', 'eventId', 'event_id'),
+		runId,
+		sessionId: stringField(record, 'sessionId', 'session_id'),
+		type,
+		status: statusField(record),
+		message: stringField(record, 'message', 'text'),
+		createdAt: stringField(record, 'createdAt', 'created_at', 'timestamp'),
+		sequence: numberField(record, 'sequence', 'seq', 'position'),
+		metadata: asRecord(record.metadata),
+		raw: record,
+	};
+}
+
+function normalizeEvents(raw: unknown, runId: string): ChatRunEvent[] {
+	const data = dataRecord(raw);
+	const events = Array.isArray(data.events) ? data.events : Array.isArray(raw) ? raw : [];
+	return events
+		.map((event) => normalizeRunEvent(event, runId))
+		.filter((event): event is ChatRunEvent => !!event);
+}
+
+function normalizeQueueResult(raw: unknown, fallback: QueueMessageInput): QueueMessageResult | void {
+	const data = dataRecord(raw);
+	const run = fallback.runId
+		? normalizeRun(data, { runId: fallback.runId, sessionId: fallback.sessionId })
+		: null;
+
+	return {
+		...(run ?? {}),
+		queuedMessageId: stringField(data, 'queuedMessageId', 'queued_message_id', 'messageId', 'message_id'),
+		position: numberField(data, 'position', 'queuePosition', 'queue_position'),
+	};
+}
+
+export function createRunControlAdapter({ fetchFn, basePath, uploadFn }: RunControlAdapterOptions): ChatRunAdapter {
+	const runPath = (runId: string, suffix = '') => compactPath(`${basePath}/runs/${encodeURIComponent(runId)}${suffix}`);
+
+	return {
+		capabilities: {
+			cancel: true,
+			queue: true,
+			status: true,
+			events: true,
+		},
+		getRunId(metadata) {
+			return stringField(metadata, 'runId', 'run_id');
+		},
+		async cancel({ runId, sessionId }) {
+			await fetchFn({
+				path: runPath(runId, '/cancel'),
+				method: 'POST',
+				data: { session_id: sessionId },
+			});
+		},
+		async queue(input) {
+			const attachments = input.files?.length && uploadFn
+				? await Promise.all(input.files.map(uploadFn))
+				: undefined;
+
+			const raw = await fetchFn({
+				path: input.runId ? runPath(input.runId, '/queue') : compactPath(`${basePath}/queue`),
+				method: 'POST',
+				data: {
+					session_id: input.sessionId,
+					run_id: input.runId,
+					message: input.content,
+					attachments,
+				},
+			});
+
+			return normalizeQueueResult(raw, input);
+		},
+		async getStatus(input) {
+			const raw = await fetchFn({ path: runPath(input.runId) });
+			return normalizeRun(dataRecord(raw), input);
+		},
+		async listEvents(input) {
+			const raw = await fetchFn({ path: runPath(input.runId, '/events') });
+			return normalizeEvents(raw, input.runId);
+		},
+	};
+}

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -56,7 +56,7 @@ export interface MediaAttachment {
 	mimeType?: string;
 	/** File size in bytes. */
 	size?: number;
-	/** WordPress media library attachment ID. */
+	/** Backend media attachment ID. */
 	mediaId?: number;
 	/** Thumbnail URL for previews. */
 	thumbnailUrl?: string;


### PR DESCRIPTION
## Summary
- Adds backend-agnostic run-control primitives for cancel, queue, status, and event access.
- Wires an optional `runAdapter` into `useChat` and `Chat` while preserving existing `runCapabilities`, `onCancelRun`, and `onQueueMessage` props.
- Adds `createRunControlAdapter()` and `useRunEvents()` so consumers can supply one generic adapter object instead of separate manual callbacks.

Closes #48.

## Testing
- `npm run build`
- `git diff --check HEAD~1 HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the run-control primitives, compatibility wiring, docs updates, and verification commands under Chris's direction.