### PR TITLE
Remove question card freeform input

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -557,9 +557,7 @@
 	background: var(--ec-chat-session-hover-bg);
 }
 
-.ec-chat-question__choice:disabled,
-.ec-chat-question__freeform-submit:disabled,
-.ec-chat-question__freeform-input:disabled {
+.ec-chat-question__choice:disabled {
 	cursor: not-allowed;
 	opacity: var(--ec-chat-send-disabled-opacity);
 }
@@ -577,48 +575,6 @@
 	color: var(--ec-chat-text-muted);
 	font-size: 12px;
 	margin-top: 4px;
-}
-
-.ec-chat-question__freeform {
-	display: flex;
-	gap: 8px;
-	align-items: flex-end;
-}
-
-.ec-chat-question__freeform-label {
-	flex: 1 1 auto;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	font-size: 12px;
-	color: var(--ec-chat-text-muted);
-}
-
-.ec-chat-question__freeform-input {
-	border: 1px solid var(--ec-chat-input-border);
-	border-radius: 999px;
-	background: var(--ec-chat-input-bg);
-	color: var(--ec-chat-text);
-	font: inherit;
-	font-size: var(--ec-chat-font-size);
-	padding: 8px 12px;
-}
-
-.ec-chat-question__freeform-input:focus {
-	border-color: var(--ec-chat-input-focus-border);
-	outline: none;
-}
-
-.ec-chat-question__freeform-submit {
-	appearance: none;
-	border: 0;
-	border-radius: 999px;
-	background: var(--ec-chat-send-bg);
-	color: var(--ec-chat-send-text);
-	cursor: pointer;
-	font: inherit;
-	font-weight: 600;
-	padding: 8px 14px;
 }
 
 /* ============================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@extrachill/chat",
-  "version": "0.12.4",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@extrachill/chat",
-      "version": "0.12.4",
+      "version": "0.14.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0"

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react';
+import { useState } from 'react';
 
 export interface QuestionChoice {
 	/** Short visible choice label. */
@@ -14,13 +14,7 @@ export interface QuestionCardProps {
 	question: string;
 	/** Model-proposed choices. */
 	choices?: QuestionChoice[];
-	/** Whether the user may type a custom answer. Defaults to true. */
-	allowFreeform?: boolean;
-	/** Label for the freeform answer input. */
-	freeformLabel?: string;
-	/** Placeholder for the freeform answer input. */
-	freeformPlaceholder?: string;
-	/** Called with the selected or typed answer. */
+	/** Called with the selected answer. */
 	onSubmitAnswer: (answer: string) => void;
 	/** Whether controls are disabled. */
 	disabled?: boolean;
@@ -31,21 +25,16 @@ export interface QuestionCardProps {
 }
 
 /**
- * Renders a structured model-proposed question with selectable choices and
- * an optional custom-answer input.
+ * Renders a structured model-proposed question with selectable choices.
  */
 export function QuestionCard({
 	question,
 	choices = [],
-	allowFreeform = true,
-	freeformLabel = 'Type your own answer',
-	freeformPlaceholder = 'Type your answer...',
 	onSubmitAnswer,
 	disabled = false,
 	autoHideOnSubmit = true,
 	className,
 }: QuestionCardProps) {
-	const [freeformAnswer, setFreeformAnswer] = useState('');
 	const [submittedAnswer, setSubmittedAnswer] = useState<string | null>(null);
 	const [showChoices, setShowChoices] = useState(false);
 	const baseClass = 'ec-chat-question';
@@ -61,14 +50,6 @@ export function QuestionCard({
 			setSubmittedAnswer(nextAnswer);
 			setShowChoices(false);
 		}
-	}
-
-	function handleSubmit(event: FormEvent) {
-		event.preventDefault();
-		const answer = freeformAnswer.trim();
-		if (!answer || controlsDisabled) return;
-		submitAnswer(answer);
-		setFreeformAnswer('');
 	}
 
 	if (submitted && autoHideOnSubmit) {
@@ -135,24 +116,6 @@ export function QuestionCard({
 						</button>
 					))}
 				</div>
-			)}
-			{allowFreeform && (
-				<form className={`${baseClass}__freeform`} onSubmit={handleSubmit}>
-					<label className={`${baseClass}__freeform-label`}>
-						{freeformLabel}
-						<input
-							className={`${baseClass}__freeform-input`}
-							type="text"
-							value={freeformAnswer}
-							onChange={(event) => setFreeformAnswer(event.target.value)}
-							placeholder={freeformPlaceholder}
-							disabled={controlsDisabled}
-						/>
-					</label>
-					<button className={`${baseClass}__freeform-submit`} type="submit" disabled={controlsDisabled || !freeformAnswer.trim()}>
-						Send
-					</button>
-				</form>
 			)}
 		</div>
 	);

--- a/src/tool-renderers.tsx
+++ b/src/tool-renderers.tsx
@@ -91,9 +91,6 @@ export function createPendingActionDiffRenderer(options: PendingActionDiffRender
 export interface QuestionToolPayload {
 	question: string;
 	choices: QuestionChoice[];
-	allowFreeform: boolean;
-	freeformLabel?: string;
-	freeformPlaceholder?: string;
 }
 
 function normalizeQuestionChoice(value: unknown): QuestionChoice | null {
@@ -128,17 +125,6 @@ export function parseQuestionPayloadFromToolGroup(group: ToolGroup): QuestionToo
 	return {
 		question,
 		choices,
-		allowFreeform: source.allowFreeform !== false && source.allow_freeform !== false,
-		freeformLabel: typeof source.freeformLabel === 'string'
-			? source.freeformLabel
-			: typeof source.freeform_label === 'string'
-				? source.freeform_label
-				: undefined,
-		freeformPlaceholder: typeof source.freeformPlaceholder === 'string'
-			? source.freeformPlaceholder
-			: typeof source.freeform_placeholder === 'string'
-				? source.freeform_placeholder
-				: undefined,
 	};
 }
 
@@ -170,9 +156,6 @@ export function createQuestionToolRenderer(options: QuestionToolRendererOptions 
 			<QuestionCard
 				question={payload.question}
 				choices={payload.choices}
-				allowFreeform={payload.allowFreeform}
-				freeformLabel={payload.freeformLabel}
-				freeformPlaceholder={payload.freeformPlaceholder}
 				disabled={disabled}
 				autoHideOnSubmit={options.autoHideOnSubmit}
 				className={options.className}


### PR DESCRIPTION
## Summary
- Remove the freeform input from question cards entirely.
- Drop freeform payload parsing and stale CSS selectors.
- Refresh the lockfile package version to match the current package version.

## Testing
- npm test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Removed the redundant question-card freeform UI, updated parser/types/CSS, and ran package tests.