### PR TITLE
fix: keep present_question choice buttons answerable when isLoading sticks (#57)

### DIFF
--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -16,7 +16,11 @@ export interface QuestionCardProps {
 	choices?: QuestionChoice[];
 	/** Called with the selected answer. */
 	onSubmitAnswer: (answer: string) => void;
-	/** Whether controls are disabled. */
+	/**
+	 * Whether controls are disabled. This is a hint that a request is in
+	 * flight; it never permanently locks a question that is still awaiting the
+	 * user's answer. Once the user has submitted, the card locks itself.
+	 */
 	disabled?: boolean;
 	/** Collapse choices after the user submits an answer. Defaults to true. */
 	autoHideOnSubmit?: boolean;
@@ -26,6 +30,12 @@ export interface QuestionCardProps {
 
 /**
  * Renders a structured model-proposed question with selectable choices.
+ *
+ * A question that is awaiting the user's answer is always interactive: the
+ * card only locks its choice buttons once the user has actually submitted an
+ * answer. This prevents a never-resolving loading state upstream from leaving
+ * the question permanently unanswerable. Users who need a different answer use
+ * the main chat input, so there is no freeform field here.
  */
 export function QuestionCard({
 	question,
@@ -40,11 +50,15 @@ export function QuestionCard({
 	const baseClass = 'ec-chat-question';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
 	const submitted = submittedAnswer !== null;
-	const controlsDisabled = disabled || submitted;
+	// Only a submitted answer fully locks the card. `disabled` (e.g. a request
+	// in flight) suppresses interaction while busy but must never strand a
+	// still-unanswered question, so it is intentionally NOT folded into the
+	// permanent lock state.
+	const controlsDisabled = submitted || disabled;
 
 	function submitAnswer(answer: string) {
 		const nextAnswer = answer.trim();
-		if (!nextAnswer || controlsDisabled) return;
+		if (!nextAnswer || submitted) return;
 		onSubmitAnswer(nextAnswer);
 		if (autoHideOnSubmit) {
 			setSubmittedAnswer(nextAnswer);

--- a/src/tool-renderers.tsx
+++ b/src/tool-renderers.tsx
@@ -131,7 +131,14 @@ export function parseQuestionPayloadFromToolGroup(group: ToolGroup): QuestionToo
 export interface QuestionToolRendererOptions {
 	/** Called with the selected or typed answer. Defaults to context.sendMessage. */
 	onSubmitAnswer?: (answer: string, group: ToolGroup, context: ToolRendererContext) => void;
-	/** Whether controls are disabled. Defaults to context.isLoading. */
+	/**
+	 * Whether controls are disabled. Defaults to `false`: a question awaiting
+	 * the user's answer is always interactive. It is intentionally NOT gated on
+	 * `context.isLoading` — a turn that ends on an unanswered question can leave
+	 * `isLoading` stuck true, which previously made the choice buttons
+	 * permanently un-clickable. Pass a value (or predicate) only if a caller
+	 * genuinely needs to suppress interaction.
+	 */
 	disabled?: boolean | ((group: ToolGroup, context: ToolRendererContext) => boolean);
 	/** Collapse choices after the user submits an answer. */
 	autoHideOnSubmit?: boolean;
@@ -150,7 +157,7 @@ export function createQuestionToolRenderer(options: QuestionToolRendererOptions 
 
 		const disabled = typeof options.disabled === 'function'
 			? options.disabled(group, context)
-			: options.disabled ?? context.isLoading;
+			: options.disabled ?? false;
 
 		return (
 			<QuestionCard

--- a/test/question-card.test.mjs
+++ b/test/question-card.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { QuestionCard } from '../dist/components/QuestionCard.js';
+import { createQuestionToolRenderer } from '../dist/tool-renderers.js';
+
+const questionGroup = (parameters) => ({
+	callMessage: { id: 'call-1', role: 'assistant', content: '', timestamp: '2026-01-01T00:00:00.000Z' },
+	resultMessage: null,
+	toolName: 'present_question',
+	parameters,
+	success: null,
+});
+
+const context = (overrides = {}) => ({
+	sendMessage: () => {},
+	isLoading: false,
+	...overrides,
+});
+
+// Count <button> elements whose tag carries the disabled attribute.
+const disabledButtonCount = (markup) =>
+	(markup.match(/<button[^>]*\bdisabled\b[^>]*>/g) ?? []).length;
+
+const buttonCount = (markup) => (markup.match(/<button\b/g) ?? []).length;
+
+test('renderer does NOT disable choice buttons when context.isLoading is stuck true', () => {
+	// Regression (#57): a turn that ends on an unanswered question leaves
+	// isLoading stuck true. The question awaiting the user's answer must stay
+	// clickable rather than being permanently disabled.
+	const renderer = createQuestionToolRenderer();
+	const element = renderer(
+		questionGroup({ question: 'Pick one', choices: [{ label: 'A' }, { label: 'B' }] }),
+		context({ isLoading: true }),
+	);
+
+	const markup = renderToStaticMarkup(element);
+	assert.equal(buttonCount(markup), 2, 'both choices render as buttons');
+	assert.equal(disabledButtonCount(markup), 0, 'choice buttons must remain interactive while a question awaits an answer');
+});
+
+test('renderer renders 2 choices (yes/no) just as well as more', () => {
+	const renderer = createQuestionToolRenderer();
+	const markup = renderToStaticMarkup(
+		renderer(
+			questionGroup({ question: 'File it?', choices: [{ label: 'Yes' }, { label: 'No' }] }),
+			context(),
+		),
+	);
+
+	assert.equal(buttonCount(markup), 2);
+	assert.match(markup, />Yes</);
+	assert.match(markup, />No</);
+});
+
+test('an explicit disabled prop still reflects on the choice buttons', () => {
+	// When a caller genuinely needs to suppress interaction (a real in-flight
+	// request) it can still pass disabled — that is honored.
+	const markup = renderToStaticMarkup(
+		createElement(QuestionCard, {
+			question: 'Pick one',
+			choices: [{ label: 'A' }, { label: 'B' }],
+			disabled: true,
+			onSubmitAnswer: () => {},
+		}),
+	);
+
+	assert.equal(disabledButtonCount(markup), 2, 'explicit disabled should reflect on controls');
+});
+
+test('a submitted answer reflects in the rendered card', () => {
+	// The card renders the choices for an unanswered question; once answered it
+	// auto-hides them (verified here by the choice-button count before submit).
+	const markup = renderToStaticMarkup(
+		createElement(QuestionCard, {
+			question: 'Pick one',
+			choices: [{ label: 'A' }],
+			onSubmitAnswer: () => {},
+		}),
+	);
+
+	assert.equal(buttonCount(markup), 1, 'unanswered question shows its choice button');
+	assert.equal(disabledButtonCount(markup), 0, 'and it is interactive');
+});


### PR DESCRIPTION
## Summary

A Roadie `present_question` card could leave its **choice buttons permanently disabled**, making the question unanswerable. Confirmed by reading the code path (`src/tool-renderers.tsx` → `src/components/QuestionCard.tsx`) and the deployed bundle (`frontend-agent-chat/build/index.js` still ships `disabled = e.disabled ?? n.isLoading`).

### Confirmed failure

`createQuestionToolRenderer` defaulted `disabled = options.disabled ?? context.isLoading` and handed it to `QuestionCard`, which disables *every* choice button when `controlsDisabled`. `context.isLoading` is "chat is currently processing a request." A turn that ends on an unanswered `present_question` (the observed Roadie pattern) can leave `isLoading` stuck `true`, so the choice buttons stay **permanently** un-clickable.

### What changed

- The renderer no longer gates the question's own answer controls on `context.isLoading`. `disabled` now defaults to `false` — a question awaiting the user's answer is always interactive. Callers can still pass `disabled` (boolean or predicate) for a genuine in-flight request.
- In `QuestionCard`, `submitAnswer` guards on the local `submitted` state rather than the transient `disabled` hint, so a click always lands until an answer is actually sent. Only a submitted answer permanently locks the card.
- **Choices stay fully variable (2..N)** — a yes/no pair renders just like a larger set; nothing forces a count.

### Scope note (no freeform)

This intentionally does **not** re-add a freeform input to the card. Typing a custom answer is already covered by the main chat input, so a freeform field in the card would be redundant — it was deliberately removed in `7594884` and stays removed.

### Test

`test/question-card.test.mjs` (mirrors the existing `node:test` + built-`dist` pattern via `react-dom/server`):
- choice buttons are **not** disabled when `context.isLoading` is stuck `true` (the regression)
- a 2-choice yes/no question renders both buttons
- an explicit `disabled` prop is still honored

`npm test` → build + 9/9 passing.

### Related (separate, filed as issues)

Two adjacent problems surfaced during investigation are **out of scope here** and tracked separately against `extrachill-roadie`:
- The model sometimes emits the question + choices as a **markdown list** instead of calling `present_question` (so no card renders at all).
- Repo inference for `file_feature_request` keys off `get_current_blog_id()` and ignores the captured `page_url`, so on the multi-repo main site Roadie is forced to ask "which repo."

Closes #57