### PR TITLE
feat: shape-based tool renderer dispatch (render choices off result shape, not tool name)

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -7,7 +7,7 @@ import { useChat, type UseChatOptions } from './hooks/useChat.ts';
 import { useLoadingMessages, type LoadingMessagesConfig } from './hooks/useLoadingMessages.ts';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
 import { AvailabilityGate } from './components/AvailabilityGate.tsx';
-import { ChatMessages } from './components/ChatMessages.tsx';
+import { ChatMessages, type ShapeRenderer } from './components/ChatMessages.tsx';
 import { ChatInput } from './components/ChatInput.tsx';
 import { TypingIndicator } from './components/TypingIndicator.tsx';
 import { SessionSwitcher } from './components/SessionSwitcher.tsx';
@@ -65,6 +65,16 @@ export interface ChatProps {
 	 * the default ToolMessage JSON display.
 	 */
 	toolRenderers?: Record<string, ToolRenderer>;
+	/**
+	 * Ordered list of shape-detecting renderers, tried when no tool-name
+	 * renderer in `toolRenderers` matches a tool group.
+	 *
+	 * Unlike `toolRenderers` (keyed by tool *name*), these dispatch off the
+	 * *shape* of a tool group's result — so any tool whose result carries a
+	 * recognized payload (e.g. a `{question, choices}` shape) renders the same
+	 * way, with zero hardcoded tool names. Forwarded to {@link ChatMessages}.
+	 */
+	shapeRenderers?: ShapeRenderer[];
 	/** Placeholder text for the input. */
 	placeholder?: string;
 	/** Content shown when conversation is empty. */
@@ -225,6 +235,7 @@ export function Chat({
 	showTools = true,
 	toolNames,
 	toolRenderers,
+	shapeRenderers,
 	placeholder,
 	emptyState,
 	messageSuggestions,
@@ -384,6 +395,7 @@ export function Chat({
 					showTools={showTools}
 					toolNames={toolNames}
 					toolRenderers={toolRenderers}
+					shapeRenderers={shapeRenderers}
 					toolRendererContext={{
 						sendMessage: chat.sendMessage,
 						isLoading: chat.isLoading,

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -4,6 +4,17 @@ import { buildMessageTimeline } from '../tool-timeline.ts';
 import { ChatMessage } from './ChatMessage.tsx';
 import { ToolMessage, type ToolRenderer, type ToolRendererContext } from './ToolMessage.tsx';
 
+/**
+ * A renderer that dispatches off the *shape* of a tool group rather than its
+ * tool name. It must return `null` when the group does not match its expected
+ * shape so the next shape renderer (or the default `ToolMessage`) can take over.
+ *
+ * It is structurally identical to `ToolRenderer`; the distinct alias documents
+ * the contract that a shape renderer is safe to attempt on *any* tool group and
+ * will opt out by returning `null` when the shape does not match.
+ */
+export type ShapeRenderer = ToolRenderer;
+
 export interface ChatMessagesProps {
 	/** All messages in the conversation. */
 	messages: ChatMessageType[];
@@ -31,6 +42,23 @@ export interface ChatMessagesProps {
 	 * ```
 	 */
 	toolRenderers?: Record<string, ToolRenderer>;
+	/**
+	 * Ordered list of shape-detecting renderers, tried when no tool-name
+	 * renderer matches `group.toolName`.
+	 *
+	 * Unlike `toolRenderers` (keyed by tool *name*), these dispatch off the
+	 * *shape* of a tool group's result — so any tool whose result carries a
+	 * recognized payload (e.g. a `{question, choices}` shape) renders the same
+	 * way, with zero hardcoded tool names. Each renderer must return `null`
+	 * when it cannot handle the group; the first non-null result wins.
+	 * If every shape renderer returns `null`, the default `ToolMessage` is used.
+	 *
+	 * @example
+	 * ```tsx
+	 * shapeRenderers={[createQuestionToolRenderer()]}
+	 * ```
+	 */
+	shapeRenderers?: ShapeRenderer[];
 	/** Action context passed to custom tool renderers. */
 	toolRendererContext?: ToolRendererContext;
 	/** Whether to auto-scroll to bottom on new messages. Defaults to true. */
@@ -56,6 +84,7 @@ export function ChatMessages({
 	showTools = false,
 	toolNames,
 	toolRenderers,
+	shapeRenderers,
 	toolRendererContext,
 	autoScroll = true,
 	emptyState,
@@ -118,6 +147,23 @@ export function ChatMessages({
 								{customRenderer(item.group, rendererContext)}
 							</div>
 						);
+					}
+
+					// No tool-name renderer matched. Try shape-detecting
+					// renderers in order; the first non-null result wins.
+					// Dispatch is by result shape, not tool name — so any tool
+					// carrying a recognized payload renders the same way.
+					if (shapeRenderers) {
+						for (const shapeRenderer of shapeRenderers) {
+							const rendered = shapeRenderer(item.group, rendererContext);
+							if (rendered !== null && rendered !== undefined) {
+								return (
+									<div key={item.group.callMessage.id}>
+										{rendered}
+									</div>
+								);
+							}
+						}
 					}
 
 					return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export {
 export {
 	ChatMessages,
 	type ChatMessagesProps,
+	type ShapeRenderer,
 } from './components/ChatMessages.tsx';
 
 export {

--- a/test/shape-dispatch.test.mjs
+++ b/test/shape-dispatch.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ChatMessages } from '../dist/components/ChatMessages.js';
+import { createQuestionToolRenderer } from '../dist/tool-renderers.js';
+
+// A tool call + result pair whose result carries a {question, choices} shape,
+// but whose tool name is deliberately NOT "present_question".
+const messages = (toolName, resultContent) => [
+	{
+		id: 'assistant-1',
+		role: 'assistant',
+		content: '',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		toolCalls: [{ id: 'call-1', name: toolName, parameters: {} }],
+	},
+	{
+		id: 'result-1',
+		role: 'tool_result',
+		content: resultContent,
+		timestamp: '2026-01-01T00:00:01.000Z',
+		toolResult: { toolName, success: true, toolCallId: 'call-1' },
+	},
+];
+
+const buttonCount = (markup) => (markup.match(/<button\b/g) ?? []).length;
+
+test('shape renderer renders a QuestionCard for a tool NOT named present_question', () => {
+	const markup = renderToStaticMarkup(
+		createElement(ChatMessages, {
+			showTools: true,
+			shapeRenderers: [createQuestionToolRenderer()],
+			messages: messages(
+				'file_feature_request',
+				JSON.stringify({
+					result: {
+						question: 'Which repo should this issue go to?',
+						choices: [
+							{ label: 'extrachill-blog', message: 'extrachill-blog' },
+							{ label: 'extrachill-roadie', message: 'extrachill-roadie' },
+						],
+					},
+				}),
+			),
+		}),
+	);
+
+	assert.match(markup, />Which repo should this issue go to\?</, 'the question text renders');
+	assert.equal(buttonCount(markup), 2, 'both choices render as clickable buttons');
+	assert.doesNotMatch(markup, /ec-chat-tool__json/, 'it does not fall through to the default ToolMessage JSON dump');
+});
+
+test('shape renderer is skipped (falls through to ToolMessage) when there is no question shape', () => {
+	const markup = renderToStaticMarkup(
+		createElement(ChatMessages, {
+			showTools: true,
+			shapeRenderers: [createQuestionToolRenderer()],
+			messages: messages('deploy', JSON.stringify({ result: { ok: true } })),
+		}),
+	);
+
+	// No QuestionCard; the default collapsible ToolMessage is used instead.
+	assert.match(markup, /ec-chat-tool\b/, 'default ToolMessage renders for an unrecognized shape');
+});
+
+test('tool-name renderers still take precedence over shape renderers', () => {
+	const markup = renderToStaticMarkup(
+		createElement(ChatMessages, {
+			showTools: true,
+			toolRenderers: {
+				custom_tool: () => createElement('div', { className: 'name-keyed-wins' }, 'name-keyed'),
+			},
+			shapeRenderers: [createQuestionToolRenderer()],
+			messages: messages(
+				'custom_tool',
+				JSON.stringify({ result: { question: 'Should not render', choices: [{ label: 'A' }] } }),
+			),
+		}),
+	);
+
+	assert.match(markup, /name-keyed-wins/, 'the name-keyed renderer is used');
+	assert.doesNotMatch(markup, />Should not render</, 'the shape renderer did not fire');
+});


### PR DESCRIPTION
## What changed

- **Shape-based dispatch in `ChatMessages`.** When no tool-*name* renderer matches a tool group's `toolName`, `ChatMessages` now tries an ordered list of **shape-detecting renderers** (new `shapeRenderers?: ShapeRenderer[]` prop) *before* falling back to the default `ToolMessage`. The first non-null result wins; if every shape renderer returns `null`, the default `ToolMessage` renders exactly as today.
- **New `ShapeRenderer` type** (alias of `ToolRenderer`) exported from the public API (`src/index.ts`), documenting the contract: a shape renderer is safe to attempt on *any* tool group and opts out by returning `null`.
- The existing generic parser `parseQuestionPayloadFromToolGroup` + `createQuestionToolRenderer()` are the first registered shape renderer — they were already shape-based and freeform-default-on; this PR just wires them into the name-miss fallback path. No changes to the parser were needed.
- Added `test/shape-dispatch.test.mjs` covering: a tool **not** named `present_question` whose result is `{result:{question,choices}}` renders a `QuestionCard`; an unrecognized shape falls through to `ToolMessage`; and name-keyed renderers still take precedence over shape renderers.

## Why

Implements the renderer-side half of **Extra-Chill/extrachill-roadie#61**: *multiple-choice is the default ask-shape; the chat box is the universal escape hatch.* Previously a `QuestionCard` rendered **only** when a tool result's name matched the literal string `present_question` (`toolRenderers?.[group.toolName]`, a strict per-tool-name `Record`). That tool-name keying blocked generic rendering — any handler holding a bounded candidate set (e.g. `file_feature_request` repo-disambiguation) had to be re-rendered via a model decision to call `present_question`. Now any tool carrying a `{question, choices}` result renders a card off **result shape**, with **zero hardcoded tool names** in the choice layer.

## Layer purity (RULES.md)

`grep -rE 'file_feature_request|present_question' src/` → **no matches**. The new capability is name-agnostic: dispatch is by shape, optionally narrowed by a caller-provided `shapeRenderers` list. Adding a new candidate-producing tool gets choice rendering for free — a config/data change downstream, not a code change in this layer.

## Backwards compatibility / non-regressions

- `present_question` (name-keyed via `toolRenderers`) still works — name-keyed renderers are tried first and take precedence.
- Diff (`edit_post_blocks`/`replace_post_blocks`/`insert_content`) and artifact renderers are name-keyed and unaffected.
- **Freeform stays default-on and non-blocking** — `parseQuestionPayloadFromToolGroup` already defaults `allowFreeform` to true and `createQuestionToolRenderer` does not gate on `context.isLoading` (#57 fix). This PR does not touch that path.
- `npm run build` (tsc) and `npm test` (12 tests) pass; `tsc --noEmit` clean.

## Downstream consumers (separate PRs)

- **frontend-agent-chat** must pass the question shape-renderer into `ChatMessages` via the new `shapeRenderers` prop (branch `consume-choice-dispatch`).
- **extrachill-roadie** must return structured `{question, choices}` from handlers (e.g. `file_feature_request` repo-disambiguation + dedupe) instead of prose hints. Cross-ref **Extra-Chill/extrachill-roadie#61**.

## Cross-references

- Implements part of **Extra-Chill/extrachill-roadie#61**.
- Complements **Extra-Chill/chat#57** (the `QuestionCard` "stuck disabled buttons" renderer fix) — that fixed a card once it exists; this makes the card exist off result shape.