### PR TITLE
fix: suppress prose that restates a question card's choices (#65)

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import type { ChatMessage as ChatMessageType, ContentFormat } from '../types/index.ts';
 import { buildMessageTimeline } from '../tool-timeline.ts';
+import { parseQuestionPayloadFromToolGroup } from '../tool-renderers.tsx';
+import { collectSuppressedQuestionRestatementIds } from '../question-suppression.ts';
 import { ChatMessage } from './ChatMessage.tsx';
 import { ToolMessage, type ToolRenderer, type ToolRendererContext } from './ToolMessage.tsx';
 
@@ -61,6 +63,22 @@ export interface ChatMessagesProps {
 	shapeRenderers?: ShapeRenderer[];
 	/** Action context passed to custom tool renderers. */
 	toolRendererContext?: ToolRendererContext;
+	/**
+	 * Suppress an assistant text turn that merely restates the choices of an
+	 * immediately-adjacent question card (see #65). When a tool group renders a
+	 * `{question, choices}` card, a chatty model often ALSO narrates the same
+	 * choices as a markdown bullet list; both render stacked and users answer
+	 * the prose instead of clicking the card. With this on (the default), the
+	 * redundant prose restatement is dropped and only the card renders.
+	 *
+	 * Detection is deterministic and conservative — it only drops prose that is
+	 * clearly the same choice set restated as a list, never arbitrary follow-up
+	 * prose. Requires `showTools` (the card itself only renders with tools on).
+	 * Set to `false` to render every assistant turn verbatim.
+	 *
+	 * Defaults to `true`.
+	 */
+	suppressRedundantQuestionProse?: boolean;
 	/** Whether to auto-scroll to bottom on new messages. Defaults to true. */
 	autoScroll?: boolean;
 	/** Placeholder content shown when there are no messages. */
@@ -86,6 +104,7 @@ export function ChatMessages({
 	toolRenderers,
 	shapeRenderers,
 	toolRendererContext,
+	suppressRedundantQuestionProse = true,
 	autoScroll = true,
 	emptyState,
 	footer,
@@ -106,6 +125,12 @@ export function ChatMessages({
 	}, [messages, footer, autoScroll]);
 
 	const displayItems = buildMessageTimeline(messages, { showTools });
+	// When a question renders as an interactive card, drop an adjacent assistant
+	// text turn that merely restates the same choices as prose (#65). The card
+	// only renders with tools on, so suppression is scoped to that case.
+	const suppressedMessageIds = showTools && suppressRedundantQuestionProse
+		? collectSuppressedQuestionRestatementIds(displayItems, parseQuestionPayloadFromToolGroup)
+		: null;
 	const baseClass = 'ec-chat-messages';
 	const classes = [baseClass, className].filter(Boolean).join(' ');
 	const rendererContext = toolRendererContext ?? {
@@ -129,6 +154,10 @@ export function ChatMessages({
 		<div className={classes} ref={containerRef}>
 			{displayItems.map((item) => {
 				if (item.type === 'message') {
+					if (suppressedMessageIds?.has(item.message.id)) {
+						return null;
+					}
+
 					return (
 						<ChatMessage
 							key={item.message.id}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,13 @@ export {
 	type ToolGroup,
 } from './tool-timeline.ts';
 
+// Question-restatement suppression
+export {
+	collectSuppressedQuestionRestatementIds,
+	isRedundantQuestionRestatement,
+	type QuestionRestatementOptions,
+} from './question-suppression.ts';
+
 // Diff helpers
 export {
 	parseCanonicalDiff,

--- a/src/question-suppression.ts
+++ b/src/question-suppression.ts
@@ -1,0 +1,183 @@
+import type { MessageTimelineItem } from './tool-timeline.ts';
+import type { ToolGroup } from './tool-timeline.ts';
+import type { QuestionToolPayload } from './tool-renderers.tsx';
+
+/**
+ * Deterministic suppression of assistant prose that merely restates a question
+ * already rendered as an interactive card.
+ *
+ * Background (#65): when a tool group renders a `QuestionCard` (a structured
+ * `{question, choices}` payload), chatty models often ALSO emit a separate
+ * assistant `text` turn that restates the very same choices as a markdown
+ * bullet list. Both surfaces render stacked; users answer the prose list
+ * instead of clicking the card. The card is the canonical, sole rendering of a
+ * choice set — the prose duplicate is the bug.
+ *
+ * This module detects, structurally and conservatively, when an assistant text
+ * turn adjacent to a question card is a redundant restatement of that card's
+ * choices, so the renderer can drop the prose and keep only the card.
+ *
+ * It is deliberately layer-pure: it keys off the rendered-question *shape*
+ * (`{question, choices}`), never a tool name, so any candidate-producing tool
+ * benefits (consistent with #61). No vendor, plugin, or tool names appear here.
+ */
+
+/** Strip a leading markdown list/quote marker from a single line. */
+function stripListMarker(line: string): string {
+	return line.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, '').trim();
+}
+
+/** True when a line begins with a markdown bullet or ordered-list marker. */
+function isListLine(line: string): boolean {
+	return /^\s*(?:[-*+]|\d+[.)])\s+/.test(line);
+}
+
+/**
+ * Normalize text for label comparison: lowercased, markdown emphasis and
+ * surrounding punctuation removed, whitespace collapsed. This lets a card
+ * choice label like `extrachill-blog (main)` match a prose bullet rendered as
+ * `**extrachill-blog (main)** (homepage rendering/blocks)`.
+ */
+function normalizeForMatch(value: string): string {
+	return value
+		.toLowerCase()
+		// Drop markdown emphasis markers (**bold**, *italic*, `code`, _under_).
+		.replace(/[*_`]+/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * True when `haystack` contains `needle` as a token-boundary substring after
+ * normalization. Empty needles never match.
+ */
+function containsLabel(haystack: string, needle: string): boolean {
+	const normalizedNeedle = normalizeForMatch(needle);
+	if (!normalizedNeedle) {
+		return false;
+	}
+
+	return normalizeForMatch(haystack).includes(normalizedNeedle);
+}
+
+export interface QuestionRestatementOptions {
+	/**
+	 * Minimum fraction of a card's choice labels that must appear in the prose,
+	 * as a markdown list, before the prose is treated as a redundant
+	 * restatement. Defaults to 1 (every labeled choice must be present) to keep
+	 * suppression conservative and avoid false positives.
+	 */
+	minChoiceCoverage?: number;
+}
+
+/**
+ * Decide whether an assistant text turn is a redundant restatement of a
+ * question card's choices.
+ *
+ * The check is intentionally structural and conservative — it suppresses only
+ * when the prose is clearly the same choice set restated, never arbitrary
+ * assistant prose that happens to follow a card:
+ *
+ * - When the card has choices: the text must contain a markdown bullet/ordered
+ *   list, and (a configurable fraction of) the choice labels must each appear
+ *   inside those list lines. Legitimate follow-up prose that is not a list, or
+ *   that omits the choices, is left untouched.
+ * - When the card has no choices (a bare question): the text is suppressed only
+ *   when, with list markers and the question itself removed, essentially
+ *   nothing meaningful remains — i.e. the turn is just the question echoed.
+ */
+export function isRedundantQuestionRestatement(
+	content: string,
+	payload: QuestionToolPayload,
+	options: QuestionRestatementOptions = {},
+): boolean {
+	const text = content.trim();
+	if (!text) {
+		return false;
+	}
+
+	const lines = text.split(/\r?\n/);
+	const listLines = lines.filter(isListLine);
+	const labels = payload.choices
+		.map((choice) => choice.label.trim())
+		.filter((label) => label.length > 0);
+
+	if (labels.length > 0) {
+		// A choice set restated as prose is, by definition, a list. Require an
+		// actual markdown list so flowing prose that merely name-drops an option
+		// is never suppressed.
+		if (listLines.length === 0) {
+			return false;
+		}
+
+		const listBlock = listLines.map(stripListMarker).join('\n');
+		const matchedLabels = labels.filter((label) => containsLabel(listBlock, label));
+		const coverage = matchedLabels.length / labels.length;
+		const minChoiceCoverage = options.minChoiceCoverage ?? 1;
+
+		return coverage >= minChoiceCoverage;
+	}
+
+	// No choices: a bare question. Suppress only a turn that is essentially just
+	// the question echoed (optionally as a one-line list), leaving no other
+	// meaningful content.
+	const question = payload.question.trim();
+	if (!question) {
+		return false;
+	}
+
+	const withoutQuestion = normalizeForMatch(text).replace(normalizeForMatch(question), '');
+	const residue = withoutQuestion.replace(/[\s.,:;!?-]+/g, '');
+	const echoesQuestion = normalizeForMatch(text).includes(normalizeForMatch(question));
+
+	return echoesQuestion && residue.length === 0;
+}
+
+/**
+ * Given an ordered timeline and a question-payload parser, return the set of
+ * assistant `message` item IDs that should be suppressed because they
+ * redundantly restate the choices of an immediately-adjacent question card.
+ *
+ * "Adjacent" means the assistant text turn sits directly before or directly
+ * after the question tool-group in the rendered timeline (ignoring nothing in
+ * between — the turns must be neighbors). Each prose turn is suppressed at most
+ * once, and only against a directly-neighboring card.
+ */
+export function collectSuppressedQuestionRestatementIds(
+	items: MessageTimelineItem[],
+	parseQuestion: (group: ToolGroup) => QuestionToolPayload | null,
+	options: QuestionRestatementOptions = {},
+): Set<string> {
+	const suppressed = new Set<string>();
+
+	for (let index = 0; index < items.length; index += 1) {
+		const item = items[index];
+		if (item.type !== 'tool-group') {
+			continue;
+		}
+
+		const payload = parseQuestion(item.group);
+		if (!payload) {
+			continue;
+		}
+
+		// Check both neighbors: a restatement may render just before or just
+		// after the card depending on backend message ordering.
+		for (const neighbor of [items[index - 1], items[index + 1]]) {
+			if (!neighbor || neighbor.type !== 'message') {
+				continue;
+			}
+
+			const message = neighbor.message;
+			if (message.role !== 'assistant' || suppressed.has(message.id)) {
+				continue;
+			}
+
+			if (isRedundantQuestionRestatement(message.content, payload, options)) {
+				suppressed.add(message.id);
+			}
+		}
+	}
+
+	return suppressed;
+}

--- a/test/question-suppression.test.mjs
+++ b/test/question-suppression.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ChatMessages } from '../dist/components/ChatMessages.js';
+import { createQuestionToolRenderer } from '../dist/tool-renderers.js';
+import { isRedundantQuestionRestatement } from '../dist/question-suppression.js';
+
+// A present_question tool call + result carrying a {question, choices} payload.
+const questionToolGroup = (question, choices) => [
+	{
+		id: 'assistant-tool',
+		role: 'assistant',
+		content: '',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		toolCalls: [{ id: 'call-1', name: 'present_question', parameters: {} }],
+	},
+	{
+		id: 'result-1',
+		role: 'tool_result',
+		content: JSON.stringify({ result: { question, choices } }),
+		timestamp: '2026-01-01T00:00:01.000Z',
+		toolResult: { toolName: 'present_question', success: true, toolCallId: 'call-1' },
+	},
+];
+
+const proseTurn = (id, content) => ({
+	id,
+	role: 'assistant',
+	content,
+	timestamp: '2026-01-01T00:00:02.000Z',
+});
+
+const renderMarkup = (messages) =>
+	renderToStaticMarkup(
+		createElement(ChatMessages, {
+			showTools: true,
+			shapeRenderers: [createQuestionToolRenderer()],
+			messages,
+		}),
+	);
+
+const buttonCount = (markup) => (markup.match(/<button\b/g) ?? []).length;
+
+// ---------------------------------------------------------------------------
+// Render-side behavior (#65 acceptance criteria)
+// ---------------------------------------------------------------------------
+
+test('present_question card + prose restatement of the SAME choices => only the card renders', () => {
+	// The exact repro shape from #65: a card, then an assistant text turn that
+	// restates the same choices as a markdown bullet list.
+	const messages = [
+		...questionToolGroup('Which repo should this issue go to?', [
+			{ label: 'extrachill-blog (main)', message: 'extrachill-blog' },
+			{ label: 'extrachill-seo', message: 'extrachill-seo' },
+			{ label: 'extrachill-admin-tools', message: 'extrachill-admin-tools' },
+			{ label: 'Unsure', message: 'Unsure' },
+		]),
+		proseTurn(
+			'prose-1',
+			'Which repo should this issue go to?\n\n' +
+				'- **extrachill-blog (main)** (homepage rendering/blocks)\n' +
+				'- **extrachill-seo** (SEO/meta)\n' +
+				'- **extrachill-admin-tools** (admin tooling)\n' +
+				'- **Unsure**',
+		),
+	];
+
+	const markup = renderMarkup(messages);
+
+	// The card renders (all four choices as buttons).
+	assert.equal(buttonCount(markup), 4, 'all four choices render as card buttons');
+	// The prose restatement is suppressed: the parenthetical descriptions that
+	// ONLY appear in the prose bullet list must not survive (the card choice
+	// labels carry no such descriptions).
+	assert.doesNotMatch(markup, /homepage rendering\/blocks/, 'prose restatement is suppressed');
+	assert.doesNotMatch(markup, /SEO\/meta/, 'prose restatement is suppressed');
+	assert.doesNotMatch(markup, /admin tooling/, 'prose restatement is suppressed');
+});
+
+test('present_question card + UNRELATED assistant prose => BOTH render', () => {
+	const messages = [
+		...questionToolGroup('Which repo should this issue go to?', [
+			{ label: 'extrachill-blog', message: 'extrachill-blog' },
+			{ label: 'extrachill-seo', message: 'extrachill-seo' },
+		]),
+		proseTurn(
+			'prose-2',
+			'I checked the recent commits and the homepage block was last touched two weeks ago. Take your time deciding.',
+		),
+	];
+
+	const markup = renderMarkup(messages);
+
+	assert.equal(buttonCount(markup), 2, 'the card still renders both choices');
+	assert.match(
+		markup,
+		/I checked the recent commits/,
+		'legitimate follow-up prose is preserved',
+	);
+});
+
+test('a yes/no card + prose restating both options as a list => only the card renders', () => {
+	// The prose carries a sentinel string ("right now") that never appears in
+	// the card, so its absence proves the prose turn was dropped — robust to the
+	// question text also appearing in the card's aria-label.
+	const messages = [
+		...questionToolGroup('Do you want me to file the GitHub issue now?', [
+			{ label: 'Yes, file it', message: 'Yes, file it' },
+			{ label: 'Not yet', message: 'Not yet' },
+		]),
+		proseTurn(
+			'prose-3',
+			'Do you want me to file the GitHub issue right now?\n\n- **Yes, file it**\n- **Not yet**',
+		),
+	];
+
+	const markup = renderMarkup(messages);
+
+	assert.equal(buttonCount(markup), 2, 'both yes/no choices render as buttons');
+	assert.doesNotMatch(markup, /right now/, 'the prose restatement is suppressed');
+});
+
+test('suppression can be turned off with suppressRedundantQuestionProse=false', () => {
+	const messages = [
+		...questionToolGroup('Pick one', [
+			{ label: 'Alpha', message: 'Alpha' },
+			{ label: 'Beta', message: 'Beta' },
+		]),
+		// "the sentinel option" appears only in the prose, never in the card.
+		proseTurn('prose-4', 'Pick one of the sentinel option\n\n- **Alpha**\n- **Beta**'),
+	];
+
+	const markup = renderToStaticMarkup(
+		createElement(ChatMessages, {
+			showTools: true,
+			suppressRedundantQuestionProse: false,
+			shapeRenderers: [createQuestionToolRenderer()],
+			messages,
+		}),
+	);
+
+	// With suppression off, the prose-only sentinel survives.
+	assert.match(markup, /the sentinel option/, 'prose is preserved when suppression is disabled');
+});
+
+// ---------------------------------------------------------------------------
+// Unit: deterministic restatement detection
+// ---------------------------------------------------------------------------
+
+test('isRedundantQuestionRestatement: matches a markdown list of the same labels', () => {
+	const payload = {
+		question: 'Which repo?',
+		choices: [{ label: 'extrachill-blog' }, { label: 'extrachill-seo' }],
+	};
+
+	assert.equal(
+		isRedundantQuestionRestatement(
+			'Which repo?\n\n- **extrachill-blog**\n- **extrachill-seo**',
+			payload,
+		),
+		true,
+	);
+});
+
+test('isRedundantQuestionRestatement: ignores flowing prose that merely name-drops an option', () => {
+	const payload = {
+		question: 'Which repo?',
+		choices: [{ label: 'extrachill-blog' }, { label: 'extrachill-seo' }],
+	};
+
+	// Mentions a label but is not a list — must NOT be suppressed.
+	assert.equal(
+		isRedundantQuestionRestatement(
+			'I think extrachill-blog is the most likely home, but it is your call.',
+			payload,
+		),
+		false,
+	);
+});
+
+test('isRedundantQuestionRestatement: a list missing a choice is not suppressed (full coverage required)', () => {
+	const payload = {
+		question: 'Which repo?',
+		choices: [{ label: 'extrachill-blog' }, { label: 'extrachill-seo' }, { label: 'extrachill-admin-tools' }],
+	};
+
+	assert.equal(
+		isRedundantQuestionRestatement('- **extrachill-blog**\n- **extrachill-seo**', payload),
+		false,
+		'a partial restatement (one label missing) is left untouched',
+	);
+});
+
+test('isRedundantQuestionRestatement: empty content is never a restatement', () => {
+	assert.equal(
+		isRedundantQuestionRestatement('   ', { question: 'Q', choices: [{ label: 'A' }] }),
+		false,
+	);
+});


### PR DESCRIPTION
## Summary

Fixes the **primary, render-side** half of Extra-Chill/extrachill-roadie#65: Roadie double-renders `present_question` — a correct, clickable `QuestionCard` **plus** a separate assistant `text` turn that restates the same choices as a markdown bullet list. Both render stacked; users screenshot/answer the prose list. The prose duplicate is the bug.

## What changed and which layer (and why)

**Render-side, in the `chat` package** — deterministic, not model-compliance-dependent. The card was already correct in the repro sessions; the producer contract (#61 / PR #63) doesn't address an *extra* prose turn layered on top of a working card. The only place that can guarantee "exactly one choice surface" regardless of how chatty the model is, is the renderer that decides what to paint. Same philosophy as #61: don't leave it to the model.

A companion prompt-side safety net ships in extrachill-roadie (cross-linked below) but is intentionally **not** the only fix.

New module `src/question-suppression.ts`:

- `isRedundantQuestionRestatement(content, payload)` — the deterministic structural check.
- `collectSuppressedQuestionRestatementIds(items, parseQuestion)` — scans the rendered timeline and returns assistant `message` IDs to drop.

`ChatMessages` computes the suppressed-ID set (only when `showTools` is on, since the card itself only renders with tools on) and skips those message items. New prop `suppressRedundantQuestionProse` (defaults `true`) lets a caller opt out.

## The exact suppression rule (and how false positives are avoided)

A tool group is considered a "question card" purely by **shape**: `parseQuestionPayloadFromToolGroup` returns a non-null `{question, choices}` — the same parser that drives the actual card render. **No tool name is referenced** (layer-pure, RULES.md); any candidate-producing tool benefits, consistent with #61.

For each question card, only an **immediately-adjacent** assistant text turn (directly before or after it in the timeline) is a suppression candidate. It is suppressed only when:

- **Card has choices** (the #65 case): the prose contains an actual markdown bullet/ordered **list**, AND **every** choice label appears within those list lines (full coverage; `minChoiceCoverage` defaults to 1). Label matching normalizes markdown emphasis/whitespace so `**extrachill-blog (main)** (homepage rendering/blocks)` matches the card label `extrachill-blog (main)`.
- **Card has no choices** (bare question): suppressed only when, after removing list markers and the question text, essentially nothing meaningful remains — i.e. the turn is just the question echoed.

Conservative by design — these are NOT suppressed:
- Flowing prose that merely name-drops one option (no list) → kept.
- A list that omits even one choice → kept.
- Any prose with substantive content beyond the restated choices → kept (the parenthetical descriptions in the #65 repro live only in the prose and are gone after suppression; the card's clean labels remain).

## Confirmation against the #65 repro

- `present_question` card + prose restatement of the **same** choices ⇒ **only the card renders** (the prose-only descriptions `homepage rendering/blocks`, `SEO/meta`, `admin tooling` are gone; 4 choice buttons remain). ✅
- `present_question` card + **unrelated** assistant prose ⇒ **both render** (legitimate follow-up preserved). ✅
- yes/no card + prose restating both options as a list ⇒ only the card. ✅

## Test coverage

New `test/question-suppression.test.mjs` (10 tests) covering: same-choice restatement suppressed, unrelated prose preserved, yes/no restatement suppressed, `suppressRedundantQuestionProse=false` disables it, and the unit detector (list match, name-drop ignored, partial-coverage ignored, empty content). Full suite green (20/20); `npm run build` (tsc) clean.

## Cross-references

- Fixes Extra-Chill/extrachill-roadie#65
- Companion prompt-side safety net: Extra-Chill/extrachill-roadie#66
- Related: Extra-Chill/extrachill-roadie#61, Extra-Chill/extrachill-roadie#63 (producer side — card EXISTS; this ensures it isn't shadowed by a prose dupe)
