### PR TITLE
Add rich question choice presentations

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -577,6 +577,65 @@
 	margin-top: 4px;
 }
 
+.ec-chat-question__choice-presentation {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 10px;
+}
+
+.ec-chat-question__choice-image {
+	display: block;
+	width: 100%;
+	max-height: 120px;
+	object-fit: cover;
+	border-radius: 8px;
+	border: 1px solid var(--ec-chat-border);
+}
+
+.ec-chat-question__choice-swatches {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.ec-chat-question__choice-swatch {
+	display: block;
+	width: 22px;
+	height: 22px;
+	border-radius: 999px;
+	border: 1px solid var(--ec-chat-border);
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.24);
+}
+
+.ec-chat-question__choice-font-sample {
+	display: block;
+	border: 1px solid var(--ec-chat-border);
+	border-radius: 8px;
+	padding: 8px;
+}
+
+.ec-chat-question__choice-font-heading,
+.ec-chat-question__choice-font-body,
+.ec-chat-question__choice-layout-hint {
+	display: block;
+}
+
+.ec-chat-question__choice-font-heading {
+	font-size: 16px;
+	font-weight: 700;
+}
+
+.ec-chat-question__choice-font-body,
+.ec-chat-question__choice-layout-hint {
+	color: var(--ec-chat-text-muted);
+	font-size: 12px;
+}
+
+.ec-chat-question__choice-layout-hint {
+	font-style: italic;
+}
+
 /* ============================================
    Individual Message
    ============================================ */

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -7,6 +7,23 @@ export interface QuestionChoice {
 	message?: string;
 	/** Optional supporting text shown under the label. */
 	description?: string;
+	/** Optional generic presentation hints rendered inline with the choice. */
+	presentation?: QuestionChoicePresentation;
+}
+
+export interface QuestionChoicePresentation {
+	swatches?: string[];
+	font_sample?: {
+		heading?: string;
+		body?: string;
+		heading_font?: string;
+		body_font?: string;
+	};
+	image?: {
+		url: string;
+		alt?: string;
+	};
+	layout_hint?: string;
 }
 
 export interface QuestionCardProps {
@@ -56,6 +73,71 @@ export function QuestionCard({
 	// permanent lock state.
 	const controlsDisabled = submitted || disabled;
 
+	function renderChoiceContent(choice: QuestionChoice) {
+		const presentation = choice.presentation;
+		const hasFontSample = !!(presentation?.font_sample?.heading || presentation?.font_sample?.body);
+		const hasPresentation = !!(
+			presentation?.image
+			|| presentation?.swatches?.length
+			|| hasFontSample
+			|| presentation?.layout_hint
+		);
+		return (
+			<>
+				<span className={`${baseClass}__choice-label`}>{choice.label}</span>
+				{choice.description && (
+					<span className={`${baseClass}__choice-description`}>{choice.description}</span>
+				)}
+				{presentation && hasPresentation && (
+					<span className={`${baseClass}__choice-presentation`}>
+						{presentation.image && (
+							<img
+								className={`${baseClass}__choice-image`}
+								src={presentation.image.url}
+								alt={presentation.image.alt ?? ''}
+							/>
+						)}
+						{presentation.swatches && presentation.swatches.length > 0 && (
+							<span className={`${baseClass}__choice-swatches`} aria-label="Color swatches">
+								{presentation.swatches.map((swatch, index) => (
+									<span
+										key={`${swatch}-${index}`}
+										className={`${baseClass}__choice-swatch`}
+										style={{ backgroundColor: swatch }}
+										title={swatch}
+									/>
+								))}
+							</span>
+						)}
+						{presentation.font_sample && hasFontSample && (
+							<span className={`${baseClass}__choice-font-sample`}>
+								{presentation.font_sample.heading && (
+									<span
+										className={`${baseClass}__choice-font-heading`}
+										style={presentation.font_sample.heading_font ? { fontFamily: presentation.font_sample.heading_font } : undefined}
+									>
+										{presentation.font_sample.heading}
+									</span>
+								)}
+								{presentation.font_sample.body && (
+									<span
+										className={`${baseClass}__choice-font-body`}
+										style={presentation.font_sample.body_font ? { fontFamily: presentation.font_sample.body_font } : undefined}
+									>
+										{presentation.font_sample.body}
+									</span>
+								)}
+							</span>
+						)}
+						{presentation.layout_hint && (
+							<span className={`${baseClass}__choice-layout-hint`}>{presentation.layout_hint}</span>
+						)}
+					</span>
+				)}
+			</>
+		);
+	}
+
 	function submitAnswer(answer: string) {
 		const nextAnswer = answer.trim();
 		if (!nextAnswer || submitted) return;
@@ -97,10 +179,7 @@ export function QuestionCard({
 									className={`${baseClass}__choice ${baseClass}__choice--readonly${selected ? ` ${baseClass}__choice--selected` : ''}`}
 									role="listitem"
 								>
-									<span className={`${baseClass}__choice-label`}>{choice.label}</span>
-									{choice.description && (
-										<span className={`${baseClass}__choice-description`}>{choice.description}</span>
-									)}
+									{renderChoiceContent(choice)}
 								</div>
 							);
 						})}
@@ -123,10 +202,7 @@ export function QuestionCard({
 							onClick={() => submitAnswer(choice.message ?? choice.label)}
 							disabled={controlsDisabled}
 						>
-							<span className={`${baseClass}__choice-label`}>{choice.label}</span>
-							{choice.description && (
-								<span className={`${baseClass}__choice-description`}>{choice.description}</span>
-							)}
+							{renderChoiceContent(choice)}
 						</button>
 					))}
 				</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,7 @@ export {
 	QuestionCard,
 	type QuestionCardProps,
 	type QuestionChoice,
+	type QuestionChoicePresentation,
 } from './components/QuestionCard.tsx';
 
 export {

--- a/src/tool-renderers.tsx
+++ b/src/tool-renderers.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { DiffCard, type DiffCardProps } from './components/DiffCard.tsx';
-import { QuestionCard, type QuestionChoice } from './components/QuestionCard.tsx';
+import { QuestionCard, type QuestionChoice, type QuestionChoicePresentation } from './components/QuestionCard.tsx';
 import type { ToolGroup, ToolRenderer, ToolRendererContext } from './components/ToolMessage.tsx';
 import { parseCanonicalDiffFromToolGroup } from './diff.ts';
 
@@ -24,6 +24,26 @@ function readString(source: UnknownRecord, keys: string[]): string | undefined {
 		const value = source[key];
 		if (typeof value === 'string' && value.trim()) {
 			return value.trim();
+		}
+	}
+
+	return undefined;
+}
+
+function readStringArray(source: UnknownRecord, keys: string[]): string[] | undefined {
+	for (const key of keys) {
+		const value = source[key];
+		if (!Array.isArray(value)) {
+			continue;
+		}
+
+		const strings = value
+			.filter((item): item is string => typeof item === 'string')
+			.map((item) => item.trim())
+			.filter(Boolean);
+
+		if (strings.length > 0) {
+			return strings;
 		}
 	}
 
@@ -93,6 +113,45 @@ export interface QuestionToolPayload {
 	choices: QuestionChoice[];
 }
 
+function normalizeQuestionChoicePresentation(value: unknown): QuestionChoicePresentation | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+
+	const swatches = readStringArray(value, ['swatches']);
+	const layoutHint = readString(value, ['layout_hint', 'layoutHint']);
+	const imageSource = isRecord(value.image) ? value.image : null;
+	const imageUrl = imageSource ? readString(imageSource, ['url']) : undefined;
+	const image = imageUrl
+		? {
+			url: imageUrl,
+			alt: imageSource ? readString(imageSource, ['alt']) : undefined,
+		}
+		: undefined;
+	const fontSampleSource = isRecord(value.font_sample)
+		? value.font_sample
+		: isRecord(value.fontSample)
+			? value.fontSample
+			: null;
+	const fontSample = fontSampleSource
+		? {
+			heading: readString(fontSampleSource, ['heading']),
+			body: readString(fontSampleSource, ['body']),
+			heading_font: readString(fontSampleSource, ['heading_font', 'headingFont']),
+			body_font: readString(fontSampleSource, ['body_font', 'bodyFont']),
+		}
+		: undefined;
+	const normalizedFontSample = fontSample && (fontSample.heading || fontSample.body) ? fontSample : undefined;
+
+	const presentation: QuestionChoicePresentation = {};
+	if (swatches) presentation.swatches = swatches;
+	if (normalizedFontSample) presentation.font_sample = normalizedFontSample;
+	if (image) presentation.image = image;
+	if (layoutHint) presentation.layout_hint = layoutHint;
+
+	return Object.keys(presentation).length > 0 ? presentation : undefined;
+}
+
 function normalizeQuestionChoice(value: unknown): QuestionChoice | null {
 	if (!isRecord(value)) {
 		return null;
@@ -107,6 +166,7 @@ function normalizeQuestionChoice(value: unknown): QuestionChoice | null {
 		label,
 		message: typeof value.message === 'string' ? value.message : undefined,
 		description: typeof value.description === 'string' ? value.description : undefined,
+		presentation: normalizeQuestionChoicePresentation(value.presentation),
 	};
 }
 

--- a/test/question-card.test.mjs
+++ b/test/question-card.test.mjs
@@ -70,6 +70,76 @@ test('an explicit disabled prop still reflects on the choice buttons', () => {
 	assert.equal(disabledButtonCount(markup), 2, 'explicit disabled should reflect on controls');
 });
 
+test('renderer displays rich choice presentation metadata', () => {
+	const renderer = createQuestionToolRenderer();
+	const markup = renderToStaticMarkup(
+		renderer(
+			questionGroup({
+				question: 'Pick a direction',
+				choices: [
+					{
+						label: 'Warm editorial',
+						description: 'Readable and image-led',
+						presentation: {
+							swatches: ['#f97316', '#fef3c7'],
+							font_sample: {
+								heading: 'Bold headline',
+								body: 'Comfortable body text',
+								heading_font: 'Georgia',
+								body_font: 'Arial',
+							},
+							image: {
+								url: 'https://example.com/thumb.jpg',
+								alt: 'A warm thumbnail',
+							},
+							layout_hint: 'Magazine grid',
+						},
+					},
+				],
+			}),
+			context(),
+		),
+	);
+
+	assert.match(markup, /ec-chat-question__choice-presentation/);
+	assert.match(markup, /ec-chat-question__choice-swatches/);
+	assert.match(markup, /background-color:#f97316/);
+	assert.match(markup, /src="https:\/\/example.com\/thumb.jpg"/);
+	assert.match(markup, /alt="A warm thumbnail"/);
+	assert.match(markup, />Bold headline</);
+	assert.match(markup, />Comfortable body text</);
+	assert.match(markup, />Magazine grid</);
+});
+
+test('renderer omits invalid presentation metadata for text-only fallback', () => {
+	const renderer = createQuestionToolRenderer();
+	const markup = renderToStaticMarkup(
+		renderer(
+			questionGroup({
+				question: 'Pick one',
+				choices: [
+					{
+						label: 'Text only',
+						description: 'Still works',
+						presentation: {
+							swatches: [''],
+							font_sample: { heading: '   ' },
+							image: { url: 42, alt: ['bad'] },
+							layout_hint: '',
+						},
+					},
+				],
+			}),
+			context(),
+		),
+	);
+
+	assert.match(markup, />Text only</);
+	assert.match(markup, />Still works</);
+	assert.doesNotMatch(markup, /ec-chat-question__choice-presentation/);
+	assert.doesNotMatch(markup, /<img/);
+});
+
 test('a submitted answer reflects in the rendered card', () => {
 	// The card renders the choices for an unanswered question; once answered it
 	// auto-hides them (verified here by the choice-button count before submit).


### PR DESCRIPTION
## Summary
- Add optional rich presentation metadata for question choices.
- Render color swatches, font samples, images, and layout hints inside existing question cards.
- Keep text-only choices unchanged and defensively drop invalid presentation metadata.

## Testing
- npm test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the rich question choice renderer, normalization, styles, and tests under Chris's direction.